### PR TITLE
Change upload_attachment to upsert

### DIFF
--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -82,7 +82,7 @@ class MinimalConfluence:
         return self.api.content.put(page.id, json=update_structure)
 
     def upload_attachment(self, page, fp):
-        return self.api.content(page.id).child.post(
+        return self.api.content(page.id).child.put(
             "attachment",
             format=(None, "json"),
             headers={"X-Atlassian-Token": "nocheck"},


### PR DESCRIPTION
The API method for "Create or update attachment" is PUT to the same endpoint as we POST to for "Create attachment", and the parameters are the same.

Issue #15 