### PR TITLE
Bump PyYAML dependency to 6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         'mistune==0.8.4',
         'tortilla==0.5.0',
-        'PyYAML==5.4'
+        'PyYAML==6.0'
     ],
     python_requires='>=3.6',
     entry_points={


### PR DESCRIPTION
Use latest version of PyYAML

Version 5.4 is over a year old.  The major change with major version 6 was the deprecation of Python 2, which isn't used in this project anyway.  I went through this codebase and the code of all the changes between 5.4 and 6.0, and no updates are required to our usage.

The "problem" I'm solving is compatibility when installing lots of packages and needing newer versions of some packages that require PyYAML > 5.4.  The requirement for this package to use exactly 5.4 is preventing me from using the newer version of the other packages.

It's safer to use "==" than ">", so I'm not suggesting we change that, but offer a version (1.3.1) with the updated dependency.