### PR TITLE
Remove H1 when used as page title

### DIFF
--- a/md2cf/confluence_renderer.py
+++ b/md2cf/confluence_renderer.py
@@ -62,6 +62,8 @@ class ConfluenceRenderer(mistune.Renderer):
     def header(self, text, level, raw=None):
         if self.title is None and level == 1:
             self.title = text
+            # Don't duplicate page title as a header
+            return ''
 
         return super(ConfluenceRenderer, self).header(text, level, raw=raw)
 

--- a/tests/functional/result.xml
+++ b/tests/functional/result.xml
@@ -1,4 +1,3 @@
-<h1>Markdown: Syntax</h1>
 <ul>
 <li><a href="#overview">Overview</a><ul>
 <li><a href="#philosophy">Philosophy</a></li>

--- a/tests/functional/test_full_rendering.py
+++ b/tests/functional/test_full_rendering.py
@@ -20,8 +20,10 @@ def test_full_document(script_loc):
     with open(str(script_loc.join("result.xml"))) as result_file:
         result_data = result_file.read()
 
+    # TODO: Consider using document.parse_page instead
     renderer = ConfluenceRenderer(use_xhtml=True)
     confluence_mistune = mistune.Markdown(renderer=renderer)
     confluence_content = confluence_mistune(markdown_data)
 
     assert confluence_content == result_data
+    assert renderer.title == "Markdown: Syntax"

--- a/tests/functional/test_full_rendering.py
+++ b/tests/functional/test_full_rendering.py
@@ -1,6 +1,6 @@
 import pytest
 
-from md2cf.confluence_renderer import ConfluenceRenderer
+from md2cf import document
 import mistune
 
 
@@ -20,10 +20,7 @@ def test_full_document(script_loc):
     with open(str(script_loc.join("result.xml"))) as result_file:
         result_data = result_file.read()
 
-    # TODO: Consider using document.parse_page instead
-    renderer = ConfluenceRenderer(use_xhtml=True)
-    confluence_mistune = mistune.Markdown(renderer=renderer)
-    confluence_content = confluence_mistune(markdown_data)
+    page = document.parse_page(markdown_data)
 
-    assert confluence_content == result_data
-    assert renderer.title == "Markdown: Syntax"
+    assert page.body == result_data
+    assert page.title == "Markdown: Syntax"

--- a/tests/functional/test_full_rendering.py
+++ b/tests/functional/test_full_rendering.py
@@ -14,13 +14,12 @@ def script_loc(request):
 
 
 def test_full_document(script_loc):
-    with open(str(script_loc.join("test.md"))) as test_file:
-        markdown_data = test_file.read()
+    markdown_path = script_loc.join("test.md")
 
     with open(str(script_loc.join("result.xml"))) as result_file:
         result_data = result_file.read()
 
-    page = document.parse_page(markdown_data)
+    page = document.get_page_data_from_file_path(markdown_path)
 
     assert page.body == result_data
     assert page.title == "Markdown: Syntax"


### PR DESCRIPTION
Closes #26 

This is a quick hack. I'm not sure it's compatible with all the ways that a title can be set, and I don't know if there's sufficient test coverage. To maintain backwards-compatibility, this could be a command-line option instead.