### PR TITLE
Remove duplicate password prompt

### DIFF
--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -300,7 +300,6 @@ def main():
         exit(1)
 
     if args.password is None and args.token is None:
-        print("Password:")
         args.password = getpass.getpass()
 
     confluence = api.MinimalConfluence(


### PR DESCRIPTION
`getpass` already displays a prompt, so the `print` is redundant.

```
% md2cf test.md
Password:
Password: 
```