### PR TITLE
Add environment variable for space

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ can omit the `--password` parameter and the script will prompt for it.
 
 For the security conscious out there or those who plan on
 using this as part of a pipeline, you can also supply the hostname,
-username, password, and token as **environment variables**: `CONFLUENCE_HOST`,
-`CONFLUENCE_USERNAME`, `CONFLUENCE_PASSWORD`, and `CONFLUENCE_TOKEN`.
+username, password, token, and space as **environment variables**:
+`CONFLUENCE_HOST`, `CONFLUENCE_USERNAME`, `CONFLUENCE_PASSWORD`,
+`CONFLUENCE_TOKEN`, and `CONFLUENCE_SPACE`.
 
 If you're using self-signed certificates and/or want to ignore SSL errors, add the `--insecure` option.
 

--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -26,14 +26,14 @@ def get_parser():
         "-o",
         "--host",
         help="full URL of the Confluence instance. "
-        "Can also be specified as CONFLUENCE_HOST environment variable",
+        "Can also be specified as CONFLUENCE_HOST environment variable.",
         default=os.getenv("CONFLUENCE_HOST"),
     )
     login_group.add_argument(
         "-u",
         "--username",
         help="username for logging into Confluence. "
-        "Can also be specified as CONFLUENCE_USERNAME environment variable",
+        "Can also be specified as CONFLUENCE_USERNAME environment variable.",
         default=os.getenv("CONFLUENCE_USERNAME"),
     )
     login_group.add_argument(
@@ -41,13 +41,13 @@ def get_parser():
         "--password",
         help="password for logging into Confluence. "
         "Can also be specified as CONFLUENCE_PASSWORD environment variable. "
-        "If not specified, it will be asked for interactively",
+        "If not specified, it will be asked for interactively.",
         default=os.getenv("CONFLUENCE_PASSWORD"),
     )
     login_group.add_argument(
         "--token",
         help="personal access token for logging into Confluence. "
-        "Can also be specified as CONFLUENCE_TOKEN environment variable",
+        "Can also be specified as CONFLUENCE_TOKEN environment variable.",
         default=os.getenv("CONFLUENCE_TOKEN"),
     )
     login_group.add_argument(
@@ -60,7 +60,8 @@ def get_parser():
     required_group.add_argument(
         "-s",
         "--space",
-        help="key for the Confluence space the page will be published to",
+        help="key for the Confluence space the page will be published to. "
+        "Can also be specified as CONFLUENCE_SPACE environment variable.",
         default=os.getenv("CONFLUENCE_SPACE"),
     )
 

--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -60,8 +60,8 @@ def get_parser():
     required_group.add_argument(
         "-s",
         "--space",
-        required=True,
         help="key for the Confluence space the page will be published to",
+        default=os.getenv("CONFLUENCE_SPACE"),
     )
 
     page_group = parser.add_argument_group("page information arguments")
@@ -157,7 +157,7 @@ def get_parser():
 def print_missing_parameter(parameter_name: str):
     sys.stderr.write(
         "Missing required parameter: {}\n"
-        "Use {} --help to get help.".format(parameter_name, sys.argv[0])
+        "Use {} --help to get help.\n".format(parameter_name, sys.argv[0])
     )
 
 
@@ -297,6 +297,10 @@ def main():
 
     if args.username is None and args.token is None:
         print_missing_parameter("username or bearer token")
+        exit(1)
+
+    if args.space is None:
+        print_missing_parameter("space")
         exit(1)
 
     if args.password is None and args.token is None:


### PR DESCRIPTION
Since I'll generally be using the same space for my Markdown files, this enables me rely entirely on environment variables and run `md2cf test.md`.