### PR TITLE
Support expands on get page

### DIFF
--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -27,20 +27,35 @@ class MinimalConfluence:
                 requests.packages.urllib3.exceptions.InsecureRequestWarning
             )
 
-    def get_page(self, title=None, space_key=None, page_id=None):
+    def get_page(self, title=None, space_key=None, page_id=None, additional_expansions=[]):
+        """
+        Create a new page in a space
+
+        Args:
+            title (str): the title for the page
+            space_key (str): the Confluence space for the page
+            page_id (str or int): the ID of the page
+            additional_expansions (list of str): Additional expansions that should be made when calling the api
+
+        Returns:
+            The response from the API
+
+        """
         if page_id is not None:
-            return self.api.content.get(page_id)
+            if additional_expansions is not None:
+                params = {"expand": ",".join(additional_expansions)}
+                return self.api.content.get(page_id, params=params)
+            else:
+                return self.api.content.get(page_id)
         elif title is not None:
             params = {"title": title}
             if space_key is not None:
                 params["spaceKey"] = space_key
-
             response = self.api.content.get(params=params)
-
             try:
                 # A search by title/space doesn't return full page objects, and since we don't support expansion in this implementation
                 # just yet, we just retrieve the "full" page data using the page ID for the first search result
-                return self.get_page(page_id=response.results[0].id)
+                return self.get_page(page_id=response.results[0].id, additional_expansions=additional_expansions)
             except IndexError:
                 return None
         else:


### PR DESCRIPTION
Update MinimalConfluence get_page to support additional expansions so that page ancestors can be retrieved. 

Set default expansions of version, history and space so that a search by title/space returns a mostly identical result to get by page id. (The links sections of api response differs slightly, happy to revert the behavior of this to a double lookup if you would like to maintain the same behavior)