### PR TITLE
[fix] Propagate flags in dir sync

### DIFF
--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -518,6 +518,8 @@ def collect_pages_to_upload(args):
                     skip_empty=args.skip_empty,
                     collapse_empty=args.collapse_empty,
                     beautify_folders=args.beautify_folders,
+                    remove_text_newlines=args.remove_text_newlines,
+                    strip_header=args.strip_top_header,
                     use_pages_file=args.use_pages_file,
                     use_gitignore=args.use_gitignore,
                 )


### PR DESCRIPTION
Hey Jack, thanks for merging a releasing version 1.5. We are now able to use md2cf within Compass which has been a huge win! I found a bug today where some key flags are not propagated correctly when uploading directories recursively. Here's a fix for that.
    
When syncing a directory some flags where not being respected.
    
* `--strip-top-header`
* `--remove-text-newlines`
    
Propagate these flags through the upload_dir method so that they
are respected both when uploading individual files and dirs.
