### PR TITLE
implement placeholder replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ usage: md2cf [-h] [-o HOST] [-u USERNAME] [-p PASSWORD] [--token TOKEN]
              [--insecure] [-s SPACE] [-a PARENT_TITLE | -A PARENT_ID]
              [-t TITLE] [-m MESSAGE] [-i PAGE_ID] [--prefix PREFIX]
              [--strip-top-header] [--remove-text-newlines]
-             [--replace-all-labels] [--preface-markdown [PREFACE_MARKDOWN] |
-             --preface-file PREFACE_FILE]
+             [--replace-all-labels]
+             [--replace-placeholders-file REPLACE_PLACEHOLDERS_FILE]
+             [--preface-markdown [PREFACE_MARKDOWN] | --preface-file PREFACE_FILE]
              [--postface-markdown [POSTFACE_MARKDOWN] | --postface-file
              POSTFACE_FILE] [--collapse-single-pages] [--no-gitignore]
              [--beautify-folders | --use-pages-file]
@@ -118,6 +119,51 @@ This is a document with hardcoded newlines in its paragraphs.
 
 It's not that nice to read.
 ```
+
+### Repalcing text before upload
+
+The `--replace-placeholders-file` allows to specify a YAML formated configuration file that defines strings or regular expressions to be replaces by Confluence macros or other strings.
+Example definitions can be found in [sample_placeholders.yaml](https://github.com/iamjackg/md2cf/blob/master/sample_placeholders.yaml).
+
+This configuration file supports the following replacements:
+* replace string with Confluence macro:
+
+   ```yaml
+   'string-to-be-replaced':
+     type: 'macro'
+     name: 'name-of-confluence-macro'
+     parameters:
+       'macro-parameter-name1': 'macro-parameter-value1'
+       'macro-parameter-name2': 'macro-parameter-value2'
+   ```
+
+* repalce string with an other string:
+
+   ```yaml
+   'long string to be replaced':
+     type: 'static'
+     text: 'new string'
+   ```
+
+* replace regular expression with Confluence macro:
+
+   ```yaml
+   # replace hugo-hint-macro with Confluence info-macro
+   '(?ms){{% hint [^%=]*(?!{{% /hint %}})info.*? %}}(.*?){{% /hint %}}':
+     type: 'macro'
+     name: 'info'
+     parameters:
+       icon: 'true'
+     # additions extend the macro definition as required by some Confluence macros
+     additions:
+       # \1 is replaced with group matched in regex
+       - '<ac:rich-text-body>\1</ac:rich-text-body>'
+   ```
+
+The search string is always processed using [python-re](https://docs.python.org/3/library/re.html).
+To test your regular expression you can use [Pythex](https://pythex.org/).
+For syntax of Confluence macros you can check XHTML layout in [Confluence 5.7](https://confluence.atlassian.com/display/CONF57/Macros) documentation.
+For a list of available Confluence macros see [latest Confluence macro list](https://confluence.atlassian.com/doc/macros-139387.html).
 
 ### Adding a preface and/or postface
 

--- a/md2cf/confluence_renderer.py
+++ b/md2cf/confluence_renderer.py
@@ -35,7 +35,10 @@ class ConfluenceTag(object):
             )
             if namespaced_attribs
             else "",
-            "".join([child.render() for child in self.children]),
+            "".join([child.render()
+            if isinstance(child, ConfluenceTag)
+            else child
+            for child in self.children]),
             "<![CDATA[{}]]>".format(self.text) if self.cdata else self.text,
             namespaced_name,
         )

--- a/sample_placeholders.yaml
+++ b/sample_placeholders.yaml
@@ -1,0 +1,35 @@
+---
+# yamllint disable rule:line-length
+# for regex you can test using:
+#   https://pythex.org/
+# for macro syntax see:
+#   https://confluence.atlassian.com/doc/macros-139387.html
+#   https://confluence.atlassian.com/display/CONF57/Macros
+# replace table-of-content macro of hugo theme geekdocs with Confluence macro.
+'{{< toc >}}':
+  type: 'macro'
+  name: 'toc'
+  parameters:
+    printable: 'true'
+    style: 'disc'
+    maxLevel: '4'
+    minLevel: '1'
+    class: 'bigpink'
+    type: 'list'
+    outline: 'true'
+    include: '.*'
+# replace placeholder with empty text
+'long string to be replaced as example':
+  type: 'static'
+  text: ''
+# replace hint-macro info with info-macro
+'(?ms){{% hint [^%=]*(?!{{% /hint %}})info.*? %}}(.*?){{% /hint %}}':
+  type: 'macro'
+  name: 'info'
+  parameters:
+    icon: 'true'
+    title: ''
+  # additions extend the macro definition as required by some Confluence macros
+  additions:
+    # \1 is replaced with group matched in regex
+    - '<ac:rich-text-body>\1</ac:rich-text-body>'


### PR DESCRIPTION
This PR implements the argument "--replace-placeholders-file".
It allows to specify a YAML structured file that defines a mapping of strings/regex and their replacements.
Using this file you can define that some text used in markdown files (e.g. [Hugo Shortcodes](https://gohugo.io/templates/shortcode-templates/) is replaced by text or Confluence Macros.

The added sample_placeholders.yaml show some examples.

The syntax of the file allows specifying text or regex as key.
For regex groups are supported and can be backreferenced (see example 3).

The `additions` key is a list of strings that are added without modification (e.g. example 3).
For this feature I added a check to `ConfluenceTag.render()` thus `child.render()` is only called when `child` is of type `ConfluenceTag`.

I did not implement the replacements within `ConfluenceRenderer` as it seemed impossible to extend the default functions of `mistune.Renderer` in a way that any custom configurable text will be replaced.
Instead I'm using `re.sub()` as this implementation allow to store all "magic" for a replacement within the configuration file.