### PR TITLE
change --bearer-token to --token in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ md2cf --host 'https://confluence.example.com/rest/api' --username foo --password
 Or, if using a token:
 
 ```bash
-md2cf --host 'https://confluence.example.com/rest/api' --bearer-token '2104v3ryl0ngt0k3n720' --space TEST document.md
+md2cf --host 'https://confluence.example.com/rest/api' --token '2104v3ryl0ngt0k3n720' --space TEST document.md
 ```
 
 Note that entering the password as a parameter on the command line is


### PR DESCRIPTION
The example for using a personal access token used `--bearer-token`, when the flag appears to be `--token` only.