### PR TITLE
UTF 8 support

### DIFF
--- a/md2cf/document.py
+++ b/md2cf/document.py
@@ -185,7 +185,7 @@ def get_page_data_from_file_path(
     if not isinstance(file_path, Path):
         file_path = Path(file_path)
 
-    with open(file_path) as file_handle:
+    with open(file_path, encoding = 'utf-8') as file_handle:
         markdown_lines = file_handle.readlines()
 
     page = get_page_data_from_lines(


### PR DESCRIPTION
When using a language other than English (e.g., Polish), the specific special characters "ą, ę, ź..." are replaced with other characters. Therefore, you need to add an encoding option when reading the file.