### PR TITLE
add support for blogpost content type

### DIFF
--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -83,6 +83,14 @@ def get_parser():
         "--title",
         help="a title for the page. Determined from the document if missing",
     )
+    
+    page_group.add_argument(
+        "-c",
+        "--content-type",
+        help="Content type. Default value: page. Valid values: page, blogpost.",
+        default="page",
+    )
+
     page_group.add_argument("-m", "--message", help="update message for the change")
     page_group.add_argument("-i", "--page-id", help="ID of the page to be updated")
     page_group.add_argument(
@@ -268,6 +276,7 @@ def upsert_page(
             space=page.space,
             title=page.title,
             body=page.body,
+            content_type=page.content_type,
             parent_id=page.parent_id,
             update_message=page_message,
             labels=page.labels,
@@ -444,6 +453,7 @@ def main():
     for page in pages_to_upload:
         page.space = args.space
         page.page_id = args.page_id
+        page.content_type = args.content_type
 
         if page.parent_title is None:  # This only happens for top level pages
             # If the argument is not supplied this leaves

--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -67,7 +67,7 @@ class MinimalConfluence:
             raise ValueError("At least one of title or page_id must not be None")
 
     def create_page(
-        self, space, title, body, parent_id=None, update_message=None, labels=None
+        self, space, title, body, content_type="page", parent_id=None, update_message=None, labels=None
     ):
         """
         Create a new page in a space
@@ -76,6 +76,7 @@ class MinimalConfluence:
             space (str): the Confluence space for the page
             title (str): the title for the page
             body (str): the body of the page, in Confluence Storage Format
+            content_type (str): Content type. Default value: page. Valid values: page, blogpost.
             parent_id (str or int): the ID of the parent page
             update_message (str): optional. A message that will appear in Confluence's history
             labels (list(str)): optional. The set of labels the final page should have. None leaves existing labels unchanged
@@ -86,7 +87,7 @@ class MinimalConfluence:
         """
         page_structure = {
             "title": title,
-            "type": "page",
+            "type": content_type,
             "space": {"key": space},
             "body": {"storage": {"value": body, "representation": "storage"}},
         }

--- a/md2cf/document.py
+++ b/md2cf/document.py
@@ -16,6 +16,7 @@ class Page(object):
         self,
         title: Optional[str],
         body: str,
+        content_type: Optional[str] = "page",
         attachments: Optional[List[Path]] = None,
         file_path: Optional[Path] = None,
         page_id: str = None,
@@ -26,6 +27,7 @@ class Page(object):
     ):
         self.title = title
         self.body = body
+        self.content_type = content_type
         self.file_path = file_path
         self.attachments = attachments
         if self.attachments is None:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -57,6 +57,7 @@ def test_upsert_page(mocker):
         space=page.space,
         title=page.title,
         body=page.body,
+        content_type=page.content_type,
         parent_id=mocker.sentinel.parent_page_id,
         update_message=message,
         labels=None,


### PR DESCRIPTION
Currently, only the `page` content type is supported, this MR enables the created of blog posts too.