### PR TITLE
docs(auth): Clarify usage of API tokens from Confluence

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Example basic usage:
 md2cf --host 'https://confluence.example.com/rest/api' --username foo --password bar --space TEST document.md
 ```
 
+_Note that if you generate an [API token in confluence](https://id.atlassian.com/manage-profile/security/api-tokens) that counts as a password and you still have to provide your username (e-mail in many cases)._
+
 Or, if using a token:
 
 ```bash


### PR DESCRIPTION
Clarification that API tokens generated in confluence are not to be treated as a anything but a password.
Some may confuse this as an API key or a token.

From Confluence
> A script or other process can use an API token to perform **basic authentication** with Jira Cloud applications or Confluence Cloud. You must use an API token if the Atlassian account you authenticate with has had two-step verification enabled. You should treat API tokens as securely as any other **password**. [Learn more](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)