### PR TITLE
Ignore the .git folder on a folder scan

### DIFF
--- a/md2cf/document.py
+++ b/md2cf/document.py
@@ -118,6 +118,9 @@ def get_pages_from_directory(
     for current_path, directories, file_names in os.walk(file_path):
         current_path = Path(current_path).resolve()
 
+        if git_repo.is_ignored(current_path):
+            continue
+
         markdown_files = [
             Path(current_path, file_name)
             for file_name in file_names

--- a/tests/unit/test_document.py
+++ b/tests/unit/test_document.py
@@ -3,7 +3,8 @@ from pathlib import Path
 import md2cf.document as doc
 from tests.utils import FakePage
 
-
+ROOT_GITIGNORE = """.git
+"""
 def test_page_get_content_hash():
     p = doc.Page(title="test title", body="test content")
 
@@ -16,6 +17,32 @@ def test_get_pages_from_directory(fs):
     fs.create_file("/root-folder/parent/child/child-file.md")
 
     result = doc.get_pages_from_directory(Path("/root-folder"))
+    assert result == [
+        FakePage(
+            title="root-folder-file",
+            file_path=Path("/root-folder/root-folder-file.md", parent_title=None),
+        ),
+        FakePage(title="parent", file_path=None, parent_title=None),
+        FakePage(title="child", file_path=None, parent_title="parent"),
+        FakePage(
+            title="child-file",
+            file_path=Path("/root-folder/parent/child/child-file.md"),
+            parent_title="child",
+        ),
+    ]
+
+
+def test_get_pages_from_directory_use_pages(fs):
+    fs.create_file("/root-folder/.gitignore", contents=ROOT_GITIGNORE)
+    fs.create_dir("/root-folder/.git")
+    fs.create_dir("/root-folder/.git/refs")
+    fs.create_file("/root-folder/.git/refs/test.md")
+    fs.create_file("/root-folder/root-folder-file.md")
+    fs.create_dir("/root-folder/empty-dir")
+    fs.create_file("/root-folder/parent/child/child-file.md")
+
+    result = doc.get_pages_from_directory(Path("/root-folder"), use_pages_file=True, enable_relative_links=True)
+    print(result)
     assert result == [
         FakePage(
             title="root-folder-file",


### PR DESCRIPTION
Problem:
.gitignore is not fully followed. Directory that are ignored are still scanned. Even the .git folder if you have it scan the whole git repo.


To reproduce:
Take a git repo for example, including a .gitignore file.
And run the following on the root of that repo. 

``` console
 md2cf --host https://<DOMAIN>/rest/api --token '<YOUR_TOKEN>' --space <SPACE> --enable-relative-links -A <PARENT_PAGE>  --preface-markdown 'Contents are auto-generated, do not edit here!!' --only-changed --use-pages-file --message 'Updated through ci pipeline at time with hash' .
```

It will complain that there are directories with the same name. Among those are the .git directories like `refs` etc.

Fix:
- add the `.git` folder to your `.gitignore` file
- Apply the ignore scan also on directory level.

What i read on the used dependencie for gitignore the .git directory should be auto ignored. But somehow i could not reproduce this.

issue found with python 3.11 on Mac OSX 13.3
