### PR TITLE
Markdown fragment link navigation to section from another file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,9 @@ repos:
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
-        language_version: python3.10
+        language_version: python3.11
   - repo: https://github.com/pycqa/flake8
     rev: '6.0.0'  # pick a git hash / tag to point to
     hooks:
       - id: flake8
-        language_version: python3.10
+        language_version: python3.11

--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ To avoid re-uploading unchanged content and receiving update emails when there a
 
 By default, support for relative links is disabled. To enable it, pass the `--enable-relative-links` flag. The behavior of relative links is similar to [GitHub relative links](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes#relative-links-and-image-paths-in-readme-files), with the exception that links starting with `/` are **not supported** and will be left unchanged.
 
+Reference to a section from another file is possible using Markdown fragment link navigation:
+` [link](./file.md#section-name) // note the dash!`
+
+In file.md:
+```
+## ...
+## section name
+```
+
 > :warning: Enabling this function requires two uploads for every page containing relative links. First, a page must be uploaded to Confluence with all internal links replaced by placeholders. Then, once the final Confluence link is known, the placeholders will be replaced with the appropriate links.
 
 By default, relative links that point to non-existent files (or files that are not being uploaded in the current batch) will result in an error. To ignore these errors and keep the links as they are, use the `--ignore-relative-link-errors` flag.

--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -584,7 +584,10 @@ def update_pages_with_relative_links(
             except KeyError:
                 if args.ignore_relative_link_errors:
                     page.body = page.body.replace(
-                        link_data.replacement, link_data.escaped_original
+                        link_data.replacement,
+                        link_data.escaped_original + ("#" + link_data.fragment)
+                        if link_data.fragment
+                        else "",
                     )
                     continue
                 else:
@@ -598,7 +601,10 @@ def update_pages_with_relative_links(
             # anything
             if not args.dry_run:
                 page.body = page.body.replace(
-                    link_data.replacement, confluence.get_url(page_on_confluence)
+                    link_data.replacement,
+                    confluence.get_url(page_on_confluence) + ("#" + link_data.fragment)
+                    if link_data.fragment
+                    else "",
                 )
             page_modified = True
 
@@ -717,7 +723,10 @@ def collect_pages_to_upload(args):
                 )
                 for link_data in only_page.relative_links:
                     only_page.body.replace(
-                        link_data.replacement, link_data.escaped_original
+                        link_data.replacement,
+                        link_data.escaped_original + ("#" + link_data.fragment)
+                        if link_data.fragment
+                        else "",
                     )
 
     return pages_to_upload

--- a/md2cf/confluence_renderer.py
+++ b/md2cf/confluence_renderer.py
@@ -1,13 +1,14 @@
-import urllib.parse as urlparse
 import uuid
 from pathlib import Path
 from typing import List, NamedTuple
+from urllib.parse import urlparse
 
 import mistune
 
 
 class RelativeLink(NamedTuple):
     path: str
+    fragment: str
     replacement: str
     original: str
     escaped_original: str
@@ -103,11 +104,9 @@ class ConfluenceRenderer(mistune.Renderer):
         return body_tag
 
     def link(self, link, title, text):
-        parsed_link = urlparse.urlparse(link)
+        parsed_link = urlparse(link)
         if self.enable_relative_links and (
-            not parsed_link.scheme
-            and not parsed_link.netloc
-            and not parsed_link.fragment
+            not parsed_link.scheme and not parsed_link.netloc
         ):
             # relative link
             replacement_link = f"md2cf-internal-link-{uuid.uuid4()}"
@@ -115,6 +114,7 @@ class ConfluenceRenderer(mistune.Renderer):
                 RelativeLink(
                     path=parsed_link.path,
                     replacement=replacement_link,
+                    fragment=parsed_link.fragment,
                     original=link,
                     escaped_original=mistune.escape_link(link),
                 )


### PR DESCRIPTION
Reference to a section from another file is possible using Markdown fragment link navigation:
` [link](./file.md#section-name) // note the dash!`

In file.md:
```
## ...
## section name
``` 

fix for #77 