### PR TITLE
Upgrade mistune

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: trailing-whitespace
         exclude: .bumpversion.cfg
+        args: [--markdown-linebreak-ext=md]
       - id: end-of-file-fixer
         exclude: '.bumpversion.cfg'
       - id: check-yaml

--- a/md2cf/confluence_renderer.py
+++ b/md2cf/confluence_renderer.py
@@ -133,6 +133,8 @@ class ConfluenceRenderer(mistune.HTMLRenderer):
             lang_parameter = self.parameter(name="language", value=info)
             root_element.append(lang_parameter)
         root_element.append(self.parameter(name="linenumbers", value="true"))
+        if code and code[-1] != "\n":
+            code += "\n"
         root_element.append(self.plain_text_body(code))
         return root_element.render()
 

--- a/md2cf/confluence_renderer.py
+++ b/md2cf/confluence_renderer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, NamedTuple
 
 import mistune
+from mistune.util import safe_entity
 
 
 class RelativeLink(NamedTuple):
@@ -130,7 +131,10 @@ class ConfluenceRenderer(mistune.HTMLRenderer):
     def block_code(self, code, info=None):
         root_element = self.structured_macro("code")
         if info is not None:
-            lang_parameter = self.parameter(name="language", value=info)
+            info = safe_entity(info.strip())
+        if info:
+            lang = info.split(None, 1)[0]
+            lang_parameter = self.parameter(name="language", value=lang)
             root_element.append(lang_parameter)
         root_element.append(self.parameter(name="linenumbers", value="true"))
         if code and code[-1] != "\n":

--- a/md2cf/confluence_renderer.py
+++ b/md2cf/confluence_renderer.py
@@ -64,13 +64,11 @@ class ConfluenceRenderer(mistune.HTMLRenderer):
     def __init__(
         self,
         strip_header=False,
-        remove_text_newlines=False,
         enable_relative_links=False,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.strip_header = strip_header
-        self.remove_text_newlines = remove_text_newlines
         self.attachments = list()
         self.title = None
         self.enable_relative_links = enable_relative_links
@@ -122,11 +120,6 @@ class ConfluenceRenderer(mistune.HTMLRenderer):
             )
             url = replacement_link
         return super(ConfluenceRenderer, self).link(text, url, title)
-
-    def text(self, text):
-        if self.remove_text_newlines:
-            text = text.replace("\n", " ")
-        return super().text(text)
 
     def block_code(self, code, info=None):
         root_element = self.structured_macro("code")

--- a/md2cf/document.py
+++ b/md2cf/document.py
@@ -268,7 +268,6 @@ def parse_page(
     enable_relative_links: bool = False,
 ) -> Page:
     renderer = ConfluenceRenderer(
-        use_xhtml=True,
         strip_header=strip_header,
         remove_text_newlines=remove_text_newlines,
         enable_relative_links=enable_relative_links,

--- a/md2cf/document.py
+++ b/md2cf/document.py
@@ -71,6 +71,12 @@ class Page(object):
         )
 
 
+class LineBreakIgnoringInlineParser(mistune.InlineParser):
+    def parse_softbreak(self, m, state) -> int:
+        state.append_token({"type": "text", "raw": " "})
+        return m.end()
+
+
 def find_non_empty_parent_path(
     current_dir: Path, folder_data: Dict[Path, Dict[str, Any]], default: Path
 ) -> Path:
@@ -269,10 +275,14 @@ def parse_page(
 ) -> Page:
     renderer = ConfluenceRenderer(
         strip_header=strip_header,
-        remove_text_newlines=remove_text_newlines,
         enable_relative_links=enable_relative_links,
     )
-    confluence_mistune = mistune.Markdown(renderer=renderer)
+    if remove_text_newlines:
+        inline_parser = LineBreakIgnoringInlineParser()
+    else:
+        inline_parser = mistune.InlineParser()
+
+    confluence_mistune = mistune.Markdown(renderer=renderer, inline=inline_parser)
     confluence_content = confluence_mistune("".join(markdown_lines))
 
     page = Page(

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "rich-argparse==1.0.0",
         "rich==13.0.1",
-        "mistune==0.8.4",
+        "mistune==3.0.0rc5",
         "chardet==5.1.0",
         "requests==2.28.2",
         "PyYAML==6.0",

--- a/tests/functional/result.xml
+++ b/tests/functional/result.xml
@@ -61,7 +61,8 @@ determines the header level.)</p>
 familiar with quoting passages of text in an email message, then you
 know how to create a blockquote in Markdown. It looks best if you hard
 wrap the text and put a <code>&gt;</code> before every line:</p>
-<blockquote><p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
+<blockquote>
+<p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
 consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
 Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.</p>
 <p>Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
@@ -69,7 +70,8 @@ id sem consectetuer libero luctus adipiscing.</p>
 </blockquote>
 <p>Markdown allows you to be lazy and only put the <code>&gt;</code> before the first
 line of a hard-wrapped paragraph:</p>
-<blockquote><p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
+<blockquote>
+<p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
 consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
 Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.</p>
 <p>Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
@@ -77,14 +79,17 @@ id sem consectetuer libero luctus adipiscing.</p>
 </blockquote>
 <p>Blockquotes can be nested (i.e. a blockquote-in-a-blockquote) by
 adding additional levels of <code>&gt;</code>:</p>
-<blockquote><p>This is the first level of quoting.</p>
-<blockquote><p>This is nested blockquote.</p>
+<blockquote>
+<p>This is the first level of quoting.</p>
+<blockquote>
+<p>This is nested blockquote.</p>
 </blockquote>
 <p>Back to the first level.</p>
 </blockquote>
 <p>Blockquotes can contain other Markdown elements, including headers, lists,
 and code blocks:</p>
-<blockquote><h2>This is a header.</h2>
+<blockquote>
+<h2>This is a header.</h2>
 <ol>
 <li>This is the first list item.</li>
 <li>This is the second list item.</li>
@@ -189,7 +194,8 @@ sit amet, consectetuer adipiscing elit.</p>
 delimiters need to be indented:</p>
 <ul>
 <li><p>A list item with a blockquote:</p>
-<blockquote><p>This is a blockquote
+<blockquote>
+<p>This is a blockquote
 inside a list item.</p>
 </blockquote>
 </li>

--- a/tests/functional/result.xml
+++ b/tests/functional/result.xml
@@ -96,7 +96,8 @@ and code blocks:</p>
 </ol>
 <p>Here's some example code:</p>
 <ac:structured-macro ac:name="code"><ac:parameter ac:name="linenumbers">true</ac:parameter>
-<ac:plain-text-body><![CDATA[return shell_exec("echo $input | $markdown_script");]]></ac:plain-text-body>
+<ac:plain-text-body><![CDATA[return shell_exec("echo $input | $markdown_script");
+]]></ac:plain-text-body>
 </ac:structured-macro>
 </blockquote>
 <p>Any decent text editor should make email-style quoting easy. For
@@ -204,7 +205,8 @@ to be indented <em>twice</em> -- 8 spaces or two tabs:</p>
 <ul>
 <li><p>A list item with a code block:</p>
 <ac:structured-macro ac:name="code"><ac:parameter ac:name="linenumbers">true</ac:parameter>
-<ac:plain-text-body><![CDATA[<code goes here>]]></ac:plain-text-body>
+<ac:plain-text-body><![CDATA[<code goes here>
+]]></ac:plain-text-body>
 </ac:structured-macro>
 </li>
 </ul>
@@ -218,7 +220,6 @@ block by at least 4 spaces or 1 tab.</p>
 <p>This is a normal paragraph:</p>
 <ac:structured-macro ac:name="code"><ac:parameter ac:name="linenumbers">true</ac:parameter>
 <ac:plain-text-body><![CDATA[This is a code block.
-
 ]]></ac:plain-text-body>
 </ac:structured-macro>
 <p>Here is an example of AppleScript:</p>
@@ -226,7 +227,6 @@ block by at least 4 spaces or 1 tab.</p>
 <ac:plain-text-body><![CDATA[tell application "Foo"
     beep
 end tell
-
 ]]></ac:plain-text-body>
 </ac:structured-macro>
 <p>A code block continues until it reaches a line that is not indented
@@ -240,7 +240,6 @@ ampersands and angle brackets. For example, this:</p>
 <ac:plain-text-body><![CDATA[<div class="footer">
     &copy; 2004 Foo Corporation
 </div>
-
 ]]></ac:plain-text-body>
 </ac:structured-macro>
 <p>Regular Markdown syntax is not processed within code blocks. E.g.,
@@ -249,7 +248,8 @@ it's also easy to use Markdown to write about Markdown's own syntax.</p>
 <ac:structured-macro ac:name="code"><ac:parameter ac:name="linenumbers">true</ac:parameter>
 <ac:plain-text-body><![CDATA[tell application "Foo"
     beep
-end tell]]></ac:plain-text-body>
+end tell
+]]></ac:plain-text-body>
 </ac:structured-macro>
 <h2>Span Elements</h2>
 <h3>Links</h3>

--- a/tests/functional/result.xml
+++ b/tests/functional/result.xml
@@ -129,22 +129,21 @@ Quote Level from the Text menu.</p>
 <li>McHale</li>
 <li>Parish</li>
 </ol>
-<p>It's important to note that the actual numbers you use to mark the
-list have no effect on the HTML output Markdown produces. The HTML
-Markdown produces from the above list is:</p>
-<p>If you instead wrote the list in Markdown like this:</p>
+<p>Only the first number in a list has any effect.</p>
+<p>You can therefore write the same list in Markdown like this:</p>
 <ol>
 <li>Bird</li>
 <li>McHale</li>
 <li>Parish</li>
 </ol>
-<p>or even:</p>
-<ol>
+<p>You specify a different start number, but the numbers you use for
+subsequent items will be ignored:</p>
+<ol start="3">
 <li>Bird</li>
 <li>McHale</li>
 <li>Parish</li>
 </ol>
-<p>you'd get the exact same HTML output. The point is, if you want to,
+<p>The point is, if you want to,
 you can use ordinal numbers in your ordered Markdown lists, so that
 the numbers in your source match the numbers in your published HTML.
 But if you want to be lazy, you don't have to.</p>

--- a/tests/functional/result.xml
+++ b/tests/functional/result.xml
@@ -251,6 +251,12 @@ it's also easy to use Markdown to write about Markdown's own syntax.</p>
 end tell
 ]]></ac:plain-text-body>
 </ac:structured-macro>
+<p>Indicate the language thus:</p>
+<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">python</ac:parameter>
+<ac:parameter ac:name="linenumbers">true</ac:parameter>
+<ac:plain-text-body><![CDATA[hello = "hello"
+]]></ac:plain-text-body>
+</ac:structured-macro>
 <h2>Span Elements</h2>
 <h3>Links</h3>
 <p>Markdown supports two style of links: <em>inline</em> and <em>reference</em>.</p>

--- a/tests/functional/result.xml
+++ b/tests/functional/result.xml
@@ -47,7 +47,8 @@ significantly from most other text-to-HTML formatters (including Movable
 Type's &quot;Convert Line Breaks&quot; option) which translate every line break
 character in a paragraph into a <code>&lt;br /&gt;</code> tag.</p>
 <p>When you <em>do</em> want to insert a <code>&lt;br /&gt;</code> break tag using Markdown, you
-end a line with two or more spaces, then type return.</p>
+end a line with two or more spaces, then type return, like...<br />
+this.</p>
 <h3>Headers</h3>
 <p>Markdown supports two styles of headers, [Setext] [1] and [atx] [2].</p>
 <p>Optionally, you may &quot;close&quot; atx-style headers. This is purely

--- a/tests/functional/result.xml
+++ b/tests/functional/result.xml
@@ -41,16 +41,16 @@ inspiration for Markdown's syntax is the format of plain text email.</p>
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
 blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
-<p>The implication of the "one or more consecutive lines of text" rule is
-that Markdown supports "hard-wrapped" text paragraphs. This differs
+<p>The implication of the &quot;one or more consecutive lines of text&quot; rule is
+that Markdown supports &quot;hard-wrapped&quot; text paragraphs. This differs
 significantly from most other text-to-HTML formatters (including Movable
-Type's "Convert Line Breaks" option) which translate every line break
+Type's &quot;Convert Line Breaks&quot; option) which translate every line break
 character in a paragraph into a <code>&lt;br /&gt;</code> tag.</p>
 <p>When you <em>do</em> want to insert a <code>&lt;br /&gt;</code> break tag using Markdown, you
 end a line with two or more spaces, then type return.</p>
 <h3>Headers</h3>
 <p>Markdown supports two styles of headers, [Setext] [1] and [atx] [2].</p>
-<p>Optionally, you may "close" atx-style headers. This is purely
+<p>Optionally, you may &quot;close&quot; atx-style headers. This is purely
 cosmetic -- you can use this if you think it looks better. The
 closing hashes don't even need to match the number of hashes
 used to open the header. (The number of opening hashes

--- a/tests/functional/test.md
+++ b/tests/functional/test.md
@@ -145,23 +145,22 @@ Ordered lists use numbers followed by periods:
 2.  McHale
 3.  Parish
 
-It's important to note that the actual numbers you use to mark the
-list have no effect on the HTML output Markdown produces. The HTML
-Markdown produces from the above list is:
+Only the first number in a list has any effect.
 
-If you instead wrote the list in Markdown like this:
+You can therefore write the same list in Markdown like this:
 
 1.  Bird
 1.  McHale
 1.  Parish
 
-or even:
+You specify a different start number, but the numbers you use for
+subsequent items will be ignored:
 
 3. Bird
 1. McHale
 8. Parish
 
-you'd get the exact same HTML output. The point is, if you want to,
+The point is, if you want to,
 you can use ordinal numbers in your ordered Markdown lists, so that
 the numbers in your source match the numbers in your published HTML.
 But if you want to be lazy, you don't have to.

--- a/tests/functional/test.md
+++ b/tests/functional/test.md
@@ -52,7 +52,8 @@ Type's "Convert Line Breaks" option) which translate every line break
 character in a paragraph into a `<br />` tag.
 
 When you *do* want to insert a `<br />` break tag using Markdown, you
-end a line with two or more spaces, then type return.
+end a line with two or more spaces, then type return, like...  
+this.
 
 ### Headers
 

--- a/tests/functional/test.md
+++ b/tests/functional/test.md
@@ -265,6 +265,12 @@ tell application "Foo"
 end tell
 ```
 
+Indicate the language thus:
+
+```python
+hello = "hello"
+```
+
 ## Span Elements
 
 ### Links

--- a/tests/functional/test.md
+++ b/tests/functional/test.md
@@ -86,7 +86,7 @@ line of a hard-wrapped paragraph:
 > This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
 consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
 Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
-
+>
 > Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
 id sem consectetuer libero luctus adipiscing.
 

--- a/tests/unit/test_document.py
+++ b/tests/unit/test_document.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from pathlib import Path
 
 import md2cf.document as doc
@@ -244,3 +245,26 @@ Yep.
 """
 
     assert doc.get_document_frontmatter(source_markdown.splitlines(keepends=True)) == {}
+
+
+def test_parse_page_with_newlines():
+    source_markdown = """
+Line1
+Line2
+"""
+    lines = StringIO(source_markdown).readlines()
+    assert (
+        doc.parse_page(lines, remove_text_newlines=False).body
+        == "<p>Line1\nLine2</p>\n"
+    )
+
+
+def test_parse_page_with_newlines_removed():
+    source_markdown = """
+Line1
+Line2
+"""
+    lines = StringIO(source_markdown).readlines()
+    assert (
+        doc.parse_page(lines, remove_text_newlines=True).body == "<p>Line1 Line2</p>\n"
+    )

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -146,7 +146,7 @@ def test_renderer_block_code_with_language():
 
     renderer = ConfluenceRenderer()
 
-    assert renderer.block_code(test_code, lang=test_language) == test_markup
+    assert renderer.block_code(test_code, info=test_language) == test_markup
 
 
 def test_renderer_header_sets_title():

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -112,7 +112,7 @@ def test_tag_render_with_child_and_text():
 
 def test_renderer_reinit():
     renderer = ConfluenceRenderer()
-    renderer.header("this is a title", 1)
+    renderer.heading("this is a title", 1)
     assert renderer.title is not None
 
     renderer.reinit()
@@ -153,7 +153,7 @@ def test_renderer_header_sets_title():
     test_header = "this is a header"
     renderer = ConfluenceRenderer()
 
-    renderer.header(test_header, 1)
+    renderer.heading(test_header, 1)
 
     assert renderer.title == test_header
 
@@ -162,7 +162,7 @@ def test_renderer_strips_header():
     test_header = "this is a header"
     renderer = ConfluenceRenderer(strip_header=True)
 
-    result = renderer.header(test_header, 1)
+    result = renderer.heading(test_header, 1)
 
     assert result == ""
 
@@ -171,7 +171,7 @@ def test_renderer_header_lower_level_does_not_set_title():
     test_header = "this is a header"
     renderer = ConfluenceRenderer()
 
-    renderer.header(test_header, 2)
+    renderer.heading(test_header, 2)
 
     assert renderer.title is None
 
@@ -181,8 +181,8 @@ def test_renderer_header_later_level_sets_title():
     test_header = "this is a header"
     renderer = ConfluenceRenderer()
 
-    renderer.header(test_lower_header, 2)
-    renderer.header(test_header, 1)
+    renderer.heading(test_lower_header, 2)
+    renderer.heading(test_header, 1)
 
     assert renderer.title is test_header
 
@@ -192,8 +192,8 @@ def test_renderer_header_only_sets_first_title():
     test_second_header = "this is another header"
     renderer = ConfluenceRenderer()
 
-    renderer.header(test_header, 1)
-    renderer.header(test_second_header, 1)
+    renderer.heading(test_header, 1)
+    renderer.heading(test_second_header, 1)
 
     assert renderer.title is test_header
 

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -124,7 +124,7 @@ def test_renderer_block_code():
     test_markup = (
         '<ac:structured-macro ac:name="code">'
         '<ac:parameter ac:name="linenumbers">true</ac:parameter>\n'
-        "<ac:plain-text-body><![CDATA[this is a piece of code]]></ac:plain-text-body>\n"
+        "<ac:plain-text-body><![CDATA[this is a piece of code\n]]></ac:plain-text-body>\n"
         "</ac:structured-macro>\n"
     )
 
@@ -140,7 +140,7 @@ def test_renderer_block_code_with_language():
         '<ac:structured-macro ac:name="code">'
         '<ac:parameter ac:name="language">whitespace</ac:parameter>\n'
         '<ac:parameter ac:name="linenumbers">true</ac:parameter>\n'
-        "<ac:plain-text-body><![CDATA[this is a piece of code]]></ac:plain-text-body>\n"
+        "<ac:plain-text-body><![CDATA[this is a piece of code\n]]></ac:plain-text-body>\n"
         "</ac:structured-macro>\n"
     )
 

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -207,7 +207,7 @@ def test_renderer_image_external():
 
     renderer = ConfluenceRenderer()
 
-    assert renderer.image(test_image_src, "", "") == test_image_markup
+    assert renderer.image("", test_image_src, "") == test_image_markup
     assert not renderer.attachments
 
 
@@ -223,7 +223,7 @@ def test_renderer_image_external_alt_and_title():
     renderer = ConfluenceRenderer()
 
     assert (
-        renderer.image(test_image_src, test_image_title, test_image_alt)
+        renderer.image(test_image_alt, test_image_src, test_image_title)
         == test_image_markup
     )
 
@@ -238,7 +238,7 @@ def test_renderer_image_internal_absolute():
 
     renderer = ConfluenceRenderer()
 
-    assert renderer.image(test_image_src, "", "") == test_image_markup
+    assert renderer.image("", test_image_src, "") == test_image_markup
     assert renderer.attachments == [test_image_src]
 
 
@@ -252,7 +252,7 @@ def test_renderer_image_internal_relative():
 
     renderer = ConfluenceRenderer()
 
-    assert renderer.image(test_image_src, "", "") == test_image_markup
+    assert renderer.image("", test_image_src, "") == test_image_markup
     assert renderer.attachments == [test_image_src]
 
 

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -254,12 +254,3 @@ def test_renderer_image_internal_relative():
 
     assert renderer.image("", test_image_src, "") == test_image_markup
     assert renderer.attachments == [test_image_src]
-
-
-def test_renderer_remove_text_newlines():
-    test_text = "This is a paragraph\nwith some newlines\nin it."
-    test_stripped_text = "This is a paragraph with some newlines in it."
-
-    renderer = ConfluenceRenderer(remove_text_newlines=True)
-
-    assert renderer.text(test_text) == test_stripped_text


### PR DESCRIPTION
Several substantial changes to the Mistune API, requiring alteration to our custom renderer.

Many of the changes do result in a different rendering, and where I've judged these are probably acceptable I've adjusted the tests, rather than attempt to further customise the markdown handling.

This targets a release candidate of Mistune 3, as it didn't seem worth trying to target version 2 given the newer version's impending availability.