### PR TITLE
fix: missing message in attachment creation/update

### DIFF
--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -224,9 +224,11 @@ class MinimalConfluence:
         return self._post(
             f"content/{confluence_page.id}/child/attachment/{existing_attachment.id}/"
             f"data",
-            json={"comment": message} if message else None,
             headers={"X-Atlassian-Token": "nocheck"},
-            files={"file": fp},
+            files={
+                "file": fp,
+                'comment': message if message else None
+            },
         )
 
     def create_attachment(self, confluence_page, fp, message=""):
@@ -235,7 +237,10 @@ class MinimalConfluence:
             json={"comment": message} if message else None,
             headers={"X-Atlassian-Token": "nocheck"},
             params={"allowDuplicated": "true"},
-            files={"file": fp},
+            files={
+                "file": fp,
+                'comment': message if message else None
+            },
         )
 
     def add_labels(self, page, labels):


### PR DESCRIPTION
During usage of the --only-changed flag, I've noticed an unexpected behavior.  
This flag is supposed to force the system to skip updating unchanged files by checking their checksum.  
However, **only with attachments** , the flag appears to have no effect - attachments are updated regardless of their changed state.

I have implemented a fix for this issue following the guidelines provided in the [Atlassian Confluence REST API documentation](https://docs.atlassian.com/atlassian-confluence/REST/6.6.0/#content/%7Bid%7D/child/attachment-createAttachments).

With this fix, the --only-changed flag should now function as expected, updating only the attachments that have undergone changes,