### PR TITLE
Root directory must be in pythonpath otherwise relative imports fail

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 filterwarnings =
 	# Ignore Deprecation Warning in gitignore parser until it can be fixed upstream.
 	ignore:Flags not at the start of the expression:DeprecationWarning
+pythonpath = .


### PR DESCRIPTION
This PR works around a possible breaking change in recent versions of pip.

- relative imports within the tests module rely on the project root being in the pythonpath
- whether this happens automatically via pip install --editable seems to have changed
- see https://github.com/pypa/pip/issues/12094 for the bug report on pip
- see https://github.com/iamjackg/md2cf/discussions/80 for more commentary

The following alternatives were considered:

1. Pinning pip to a version that works as assumed/expected by this project. This could be done in CI (ie by making a change to [ci.yml](.github/workflows/ci.yml). But it wouldn't help developers trying to run the tests locally.
2. Creating a `conftest.py` file in `tests`. This has a side-effect of ensuring the `tests` directory is properly imported as a module. However, while many projects won't have noticed the `pip` change because of having a conftest file, relying on this seems obscure.

In the end, explicitly configuring the project root to be in the pythonpath when running tests appears to be robust and sensible.

That by default `pytest` does not put the root directory into the pythonpath - unlike when running `python -m pytest` - is [apparently a deliberate design choice / behaviour](https://docs.pytest.org/en/7.3.x/explanation/pythonpath.html#pytest-vs-python-m-pytest), albeit one that's very confusing for people not familiar with it.