### PR TITLE
added retry attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- added support for retry attempts using `--retry-attempts`
+
 ## 2.2.1 - 2023-07-17
 ### Fixed
 - Local section links are no longer rendered as broken relative links (e.g. `[this section](#section-header)`)

--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -26,6 +26,9 @@ from md2cf.document import Page
 from md2cf.tui import Md2cfTUI
 from md2cf.upsert import upsert_attachment, upsert_page
 
+from tenacity import (Retrying, retry_if_exception_type,
+                      stop_after_attempt, wait_random)
+
 
 def get_parser():
     parser = argparse.ArgumentParser(formatter_class=RichHelpFormatter)
@@ -249,6 +252,14 @@ def get_parser():
         help="markdown files or directories to upload to Confluence. Empty for stdin",
         nargs="*",
     )
+    parser.add_argument(
+        "--retry-attempts",
+        action="store",
+        dest="retry_attempts",
+        type=int,
+        default=3,
+        help="Number of retry attemps if upload fails with HTTPError."
+    )
 
     return parser
 
@@ -290,6 +301,12 @@ def main():
     elif args.output == "json":
         console.quiet = True
         json_output_console.quiet = False
+
+    retryer = Retrying(reraise=True,
+        retry=retry_if_exception_type(HTTPError),
+        stop=stop_after_attempt(args.retry_attempts),
+        wait=wait_random(1, 10)
+    )
 
     confluence = api.MinimalConfluence(
         host=args.host,
@@ -380,6 +397,7 @@ def main():
     something_went_wrong = False
     error = None
     tui = Md2cfTUI(pages_to_upload)
+
     with tui:
         space_info = confluence.get_space(
             args.space, additional_expansions=["homepage"]
@@ -393,7 +411,7 @@ def main():
                 tui.set_item_progress_label(page.original_title, "Upserting")
                 final_page = None
                 if not args.dry_run:
-                    upsert_page_result = upsert_page(
+                    upsert_page_result = retryer(upsert_page,
                         confluence=confluence,
                         message=args.message,
                         page=page,
@@ -412,7 +430,7 @@ def main():
                         attachment_identifier = f"{page.original_title} {attachment}"
                         tui.start_item_task(attachment_identifier)
                         if not args.dry_run:
-                            upsert_attachment_result = upsert_attachment(
+                            upsert_attachment_result = retryer(upsert_attachment,
                                 confluence=confluence,
                                 attachment=attachment,
                                 existing_page=final_page,
@@ -478,6 +496,7 @@ def main():
                     pages_to_upload,
                     map_document_path_to_confluence_page,
                     tui,
+                    retryer
                 )
             except HTTPError as e:
                 if args.debug:
@@ -564,7 +583,7 @@ def build_document_path_to_page_map(pages_to_upload):
 
 
 def update_pages_with_relative_links(
-    args, confluence, pages_to_upload, path_to_page, tui
+    args, confluence, pages_to_upload, path_to_page, tui, retryer
 ):
     something_went_wrong = False
     error = ""
@@ -612,7 +631,7 @@ def update_pages_with_relative_links(
             tui.start_item_task(page.original_title)
             if not args.dry_run:
                 try:
-                    upsert_page(
+                    retryer(upsert_page,
                         confluence=confluence,
                         message=args.message,
                         page=page,
@@ -728,7 +747,6 @@ def collect_pages_to_upload(args):
                 only_page.relative_links = []
 
     return pages_to_upload
-
 
 if __name__ == "__main__":
     main()

--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -13,6 +13,7 @@ import rich.tree
 from requests import HTTPError
 from rich import box
 from rich_argparse import RichHelpFormatter
+from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_random
 
 import md2cf.document
 from md2cf import api
@@ -25,9 +26,6 @@ from md2cf.console_output import (
 from md2cf.document import Page
 from md2cf.tui import Md2cfTUI
 from md2cf.upsert import upsert_attachment, upsert_page
-
-from tenacity import (Retrying, retry_if_exception_type,
-                      stop_after_attempt, wait_random)
 
 
 def get_parser():
@@ -258,7 +256,7 @@ def get_parser():
         dest="retry_attempts",
         type=int,
         default=3,
-        help="Number of retry attemps if upload fails with HTTPError."
+        help="Number of retry attemps if upload fails with HTTPError.",
     )
 
     return parser
@@ -302,10 +300,11 @@ def main():
         console.quiet = True
         json_output_console.quiet = False
 
-    retryer = Retrying(reraise=True,
+    retryer = Retrying(
+        reraise=True,
         retry=retry_if_exception_type(HTTPError),
         stop=stop_after_attempt(args.retry_attempts),
-        wait=wait_random(1, 10)
+        wait=wait_random(1, 10),
     )
 
     confluence = api.MinimalConfluence(
@@ -411,7 +410,8 @@ def main():
                 tui.set_item_progress_label(page.original_title, "Upserting")
                 final_page = None
                 if not args.dry_run:
-                    upsert_page_result = retryer(upsert_page,
+                    upsert_page_result = retryer(
+                        upsert_page,
                         confluence=confluence,
                         message=args.message,
                         page=page,
@@ -430,7 +430,8 @@ def main():
                         attachment_identifier = f"{page.original_title} {attachment}"
                         tui.start_item_task(attachment_identifier)
                         if not args.dry_run:
-                            upsert_attachment_result = retryer(upsert_attachment,
+                            upsert_attachment_result = retryer(
+                                upsert_attachment,
                                 confluence=confluence,
                                 attachment=attachment,
                                 existing_page=final_page,
@@ -496,7 +497,7 @@ def main():
                     pages_to_upload,
                     map_document_path_to_confluence_page,
                     tui,
-                    retryer
+                    retryer,
                 )
             except HTTPError as e:
                 if args.debug:
@@ -631,7 +632,8 @@ def update_pages_with_relative_links(
             tui.start_item_task(page.original_title)
             if not args.dry_run:
                 try:
-                    retryer(upsert_page,
+                    retryer(
+                        upsert_page,
                         confluence=confluence,
                         message=args.message,
                         page=page,
@@ -747,6 +749,7 @@ def collect_pages_to_upload(args):
                 only_page.relative_links = []
 
     return pages_to_upload
+
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "requests==2.31.0",
         "PyYAML==6.0",
         "gitignorefile==1.1.2",
+        "tenacity==8.2.2",
     ],
     python_requires=">=3.7",
     entry_points={"console_scripts": ["md2cf=md2cf.__main__:main"]},


### PR DESCRIPTION
Hi @iamjackg 

I did another quick improvement on the code as we are facing a lot of issues uploading large numbers of documents to Confluence (Atlassian.com). We get sporadic `500` errors that make it almost impossible to get the process to finish completely which is especially bad when using relative links as it leaves the documents unpatched.

I did use `tenacity` to do a super simple retry on the upload logic. The number of attempts can be changed using `--retry-attempts`

Obviously the error handling could be done more sophistically, but for us this works 100%!

Cheers,
Matthias