### PR TITLE
use fixed version of PyYAML

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "mistune==0.8.4",
         "chardet==5.1.0",
         "requests==2.31.0",
-        "PyYAML==6.0",
+        "PyYAML==6.0.1",
         "gitignorefile==1.1.2",
     ],
     python_requires=">=3.7",


### PR DESCRIPTION
Proposal to solve https://github.com/iamjackg/md2cf/issues/98
Passed pytest and linting.

Calling this out explicitly here as well - 6.0 is still the latest/master version of PyYAML.  6.0.1 is available (and it fixes our issue by pinning to cython 2), but hasn't been merged to master.  They may be waiting to get in https://github.com/yaml/pyyaml/pull/731 for the real fix for 6.1.
