### PR TITLE
Added replacement facility for page content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,69 @@ folderA/
 ```
 </details>
 
+## Replacements
+
+By using either command line replacement pairs or specifying a file with json defintions of replacements an arbitrary regexp ("pattern") can be detected and replaced with another string, including expanding captured groups in the pattern.
+
+The replacement phase is taking place just before upsert, so all other textual manipulations are done by that time.
+
+Replacements happen in a deterministic sequence. There are ample opportunities to get unexpected (but logically consistent) results by inadvertently result of a previous replacement.
+<details>
+<summary>Format of json file</summary>
+
+```json
+{
+    "environment": [
+        {
+            "import": "<module name>",
+            "path": "<source file>"
+        }
+    ],
+    "replacements":[
+        {
+            "name": "<name - optional>",
+            "pattern": "<regexp>",
+            "new_value": "<string with optional group expansions>"
+            "evaluate": <true|false - optional>
+        },
+    ]
+}
+```
+</details>
+
+### Advanced replacements
+
+The `environment` block is optional and used for very dynamic replacements. By specifying a python source file, it will be dynamically imported at run time. The `new_value` field can then specify a `<module>.<func>` that returns a string value. As an example, the following adds a replacement of "TODAY" to an iso-formatted datetime.
+
+```json
+{
+    "environment": [
+        {
+            "import": "funcs",
+            "path": "funcs.py"
+        }
+    ],
+    "replacements":[
+        {
+            "name": "Todays date",
+            "pattern": "TODAY",
+            "new_value": "funcs.today"
+            "evaluate": true
+        },
+    ]
+}
+```
+
+Funcs.py
+```python
+import datetime
+
+def today(term):
+    return datetime.datetime.now().isoformat()
+```
+
+The parameter `term` is a Match object as per using [re.subn](https://docs.python.org/3/library/re.html#re.subn).
+
 ## Terminal output format
 
 By default, `md2cf` produces rich output with animated progress bars that are meant for human consumption. If the output is redirected to a file, the progress bars will not be displayed and only the final result will be written to the file. Error messages are always printed to standard error.

--- a/md2cf/replacements.py
+++ b/md2cf/replacements.py
@@ -1,0 +1,70 @@
+import importlib.util
+import json
+import re
+from typing import List
+
+from md2cf.console_output import console
+
+
+class Replacement:
+    def __init__(
+        self, name: str, pattern: str, new_value: str, evaluate: bool = False
+    ) -> None:
+        self.name = name
+        self.pattern = pattern
+        self.new_value = new_value
+        self.evaluate = evaluate
+
+    def replace(self, page):
+        console.print(f"Performing replacement '{self.name}'")
+        if self.evaluate:
+            new_value = eval(self.new_value)
+        else:
+            new_value = self.new_value
+        page.body, count = re.subn(f"({self.pattern})", new_value, page.body)
+        console.print(f">> {count} replacements made")
+        return page
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+def create_replacements(replacements, replacementfile: str) -> List[Replacement]:
+    result = []
+    commandline_replacements = (
+        [item for sublist in replacements for item in sublist] if replacements else []
+    )
+
+    # Create Replacement objects for the commandline replacements
+    for i, r in enumerate(commandline_replacements):
+        result.append(Replacement(f"CLI replacement {i}", *r.split("=", 1)))
+
+    # Opt out if no file specified
+    if not replacementfile:
+        return result
+
+    file_replacements = json.load(open(replacementfile))
+    # Do we need to load any modules?
+    for env in file_replacements.get("environment", []):
+        if env.get("import"):
+            spec = importlib.util.spec_from_file_location(
+                env["import"], env.get("path")
+            )
+            globals()[env["import"]] = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(globals()[env["import"]])
+
+    # Get the replacement definitions
+    for i, r in enumerate(file_replacements["replacements"]):
+        new_value = r["new_value"]
+        if isinstance(new_value, list):
+            new_value = "\n".join(new_value)
+        result.append(
+            Replacement(
+                r.get("name", f"File replacement {i}"),
+                r["pattern"],
+                new_value,
+                r.get("evaluate", False),
+            )
+        )
+
+    return result


### PR DESCRIPTION
By using either command line replacement pairs or specifying a file with json defintions of replacements an arbitrary regexp ("pattern") can be detected and replaced with another string, including expanding captured groups in the pattern.

The replacement phase is taking place just before upsert, so all other textual manipulations are done by that time.

Replacements happen in a deterministic sequence. There are ample opportunities to get unexpected (but logically consistent) results by inadvertently result of a previous replacement.

Format of json file:
```
{
    "environment": [
        {
            "import": "<module name>",
            "path": "<source file>"
        }
    ],
    "replacements":[
        {
            "name": "<name - optional>",
            "pattern": "<regexp>",
            "new_value": "<string with optional group expansions>"
            "evaluate": <true|false - optional>
        },
    ]
}
```
The `environment` block is optional and used for very dynamic replacements. By specifying a python source file, it will be dynamically imported at run time. The `new_value` field can then specify a `<module>.<func>` that returns a string value. As an example, the following adds a replacement of "TODAY" to an iso-formatted datetime.

```
{
    "environment": [
        {
            "import": "funcs",
            "path": "funcs.py"
        }
    ],
    "replacements":[
        {
            "name": "Todays date",
            "pattern": "TODAY",
            "new_value": "funcs.today"
            "evaluate": true
        },
    ]
}
```

Funcs.py:
```
import datetime

def today(term):
    return datetime.datetime.now().isoformat()
```

The parameter `term` is a Match object as per using https://docs.python.org/3/library/re.html#re.subn.