### PR TITLE
Add github action to build a docker image on every new release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
+
   build-publish-and-release:
     runs-on: ubuntu-latest
     steps:
@@ -49,3 +50,83 @@ jobs:
           body: ${{ steps.get-release-notes.outputs.release-notes }}
           draft: false
           prerelease: ${{ steps.get-release-notes.outputs.is-prerelease }}
+
+  dockerhub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - id: get_version
+        uses: battila7/get-version-action@v2.2.1
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
+        with:
+          cosign-release: 'v2.1.1'
+
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set outputs
+        id: vars
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      - name: Check outputs
+        run: |
+          echo ${{ steps.vars.outputs.sha_short }}
+          echo ${{ steps.vars.outputs.RELEASE_VERSION }}
+
+      - name: Build and push Docker images
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            GIT_HASH=${{ steps.vars.outputs.sha_short }}
+            VERSION=${{ steps.get_version.outputs.version-without-v }}
+          platforms: linux/arm64,linux/arm/v7,linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3-alpine
+ARG VERSION
+
+RUN mkdir -p /content && \
+    pip install md2cf==${VERSION}
+
+WORKDIR /content
+ENTRYPOINT ["/usr/local/bin/md2cf"]
+CMD ["--parent-id ${CONFLUENCE_PARENT_ID} --minor-edit --preface-markdown --only-changed --skip-empty --beautify-folders --collapse-single-pages /content"]


### PR DESCRIPTION
I added a job in the github action that creates a docker image for every new tag. This needs an extra 2 secrets in the repo (docker hub credentials). 