### PR TITLE
Update mistune

### DIFF
--- a/md2cf/confluence_renderer.py
+++ b/md2cf/confluence_renderer.py
@@ -89,7 +89,7 @@ class ConfluenceRenderer(mistune.HTMLRenderer):
         if self.remove_text_newlines:
             text = text.replace("\n", " ")
 
-        return super().text(text)
+        return text
 
     def block_code(self, code, lang=None):
         root_element = self.structured_macro("code")

--- a/md2cf/confluence_renderer.py
+++ b/md2cf/confluence_renderer.py
@@ -49,8 +49,10 @@ class ConfluenceTag(object):
         self.children.append(child)
 
 
-class ConfluenceRenderer(mistune.Renderer):
-    def __init__(self, strip_header=False, remove_text_newlines=False, **kwargs):
+class ConfluenceRenderer(mistune.HTMLRenderer):
+    def __init__(self, strip_header=False,
+                 remove_text_newlines=False,
+                 **kwargs):
         super().__init__(**kwargs)
         self.strip_header = strip_header
         self.remove_text_newlines = remove_text_newlines
@@ -61,14 +63,14 @@ class ConfluenceRenderer(mistune.Renderer):
         self.attachments = list()
         self.title = None
 
-    def header(self, text, level, raw=None):
+    def heading(self, text, level, raw=None):
         if self.title is None and level == 1:
             self.title = text
             # Don't duplicate page title as a header
             if self.strip_header:
                 return ""
 
-        return super(ConfluenceRenderer, self).header(text, level, raw=raw)
+        return super(ConfluenceRenderer, self).heading(text, level, raw=raw)
 
     def structured_macro(self, name):
         return ConfluenceTag("structured-macro", attrib={"name": name})

--- a/md2cf/document.py
+++ b/md2cf/document.py
@@ -180,7 +180,9 @@ def get_pages_from_directory(
 
 
 def get_page_data_from_file_path(
-    file_path: Path, strip_header: bool = False, remove_text_newlines: bool = False
+    file_path: Path,
+    strip_header: bool = False,
+    remove_text_newlines: bool = False,
 ) -> Page:
     if not isinstance(file_path, Path):
         file_path = Path(file_path)
@@ -234,17 +236,22 @@ def parse_page(
     markdown_lines: List[str],
     strip_header: bool = False,
     remove_text_newlines: bool = False,
+    escape: bool = False,
+    allow_harmful_protocols: bool = False
 ) -> Page:
     renderer = ConfluenceRenderer(
-        use_xhtml=True,
         strip_header=strip_header,
         remove_text_newlines=remove_text_newlines,
+        escape=escape,
+        allow_harmful_protocols=allow_harmful_protocols
     )
     confluence_mistune = mistune.Markdown(renderer=renderer)
     confluence_content = confluence_mistune("".join(markdown_lines))
 
     page = Page(
-        title=renderer.title, body=confluence_content, attachments=renderer.attachments
+        title=renderer.title,
+        body=confluence_content,
+        attachments=renderer.attachments
     )
 
     return page

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,10 @@ setup(
     ],
     keywords="markdown confluence",
     install_requires=[
-        "mistune==0.8.4",
+        "mistune==3.0.1",
         "tortilla==0.5.0",
-        "PyYAML==6.0",
-        "gitignore_parser==0.0.8",
+        "PyYAML==6.0.1",
+        "gitignore_parser==0.1.6",
     ],
     python_requires=">=3.6",
     entry_points={"console_scripts": ["md2cf=md2cf.__main__:main"]},

--- a/tests/functional/result.xml
+++ b/tests/functional/result.xml
@@ -1,24 +1,24 @@
 <h1>Markdown: Syntax</h1>
 <ul>
+<li><a href="#markdown-syntax">Markdown: Syntax</a><ul>
 <li><a href="#overview">Overview</a><ul>
 <li><a href="#philosophy">Philosophy</a></li>
-<li><a href="#html">Inline HTML</a></li>
-<li><a href="#autoescape">Automatic Escaping for Special Characters</a></li>
 </ul>
 </li>
-<li><a href="#block">Block Elements</a><ul>
-<li><a href="#p">Paragraphs and Line Breaks</a></li>
-<li><a href="#header">Headers</a></li>
-<li><a href="#blockquote">Blockquotes</a></li>
-<li><a href="#list">Lists</a></li>
-<li><a href="#precode">Code Blocks</a></li>
-<li><a href="#hr">Horizontal Rules</a></li>
+<li><a href="#block-elements">Block Elements</a><ul>
+<li><a href="#paragraphs-and-line-breaks">Paragraphs and Line Breaks</a></li>
+<li><a href="#headers">Headers</a></li>
+<li><a href="#blockquotes">Blockquotes</a></li>
+<li><a href="#lists">Lists</a></li>
+<li><a href="#code-blocks">Code Blocks</a></li>
 </ul>
 </li>
-<li><a href="#span">Span Elements</a><ul>
-<li><a href="#link">Links</a></li>
-<li><a href="#em">Emphasis</a></li>
+<li><a href="#span-elements">Span Elements</a><ul>
+<li><a href="#links">Links</a></li>
+<li><a href="#emphasis">Emphasis</a></li>
 <li><a href="#code">Code</a></li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -60,7 +60,8 @@ determines the header level.)</p>
 familiar with quoting passages of text in an email message, then you
 know how to create a blockquote in Markdown. It looks best if you hard
 wrap the text and put a <code>&gt;</code> before every line:</p>
-<blockquote><p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
+<blockquote>
+<p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
 consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
 Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.</p>
 <p>Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
@@ -68,22 +69,28 @@ id sem consectetuer libero luctus adipiscing.</p>
 </blockquote>
 <p>Markdown allows you to be lazy and only put the <code>&gt;</code> before the first
 line of a hard-wrapped paragraph:</p>
-<blockquote><p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
+<blockquote>
+<p>This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
 consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
 Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.</p>
+</blockquote>
+<blockquote>
 <p>Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
 id sem consectetuer libero luctus adipiscing.</p>
 </blockquote>
 <p>Blockquotes can be nested (i.e. a blockquote-in-a-blockquote) by
 adding additional levels of <code>&gt;</code>:</p>
-<blockquote><p>This is the first level of quoting.</p>
-<blockquote><p>This is nested blockquote.</p>
+<blockquote>
+<p>This is the first level of quoting.</p>
+<blockquote>
+<p>This is nested blockquote.</p>
 </blockquote>
 <p>Back to the first level.</p>
 </blockquote>
 <p>Blockquotes can contain other Markdown elements, including headers, lists,
 and code blocks:</p>
-<blockquote><h2>This is a header.</h2>
+<blockquote>
+<h2>This is a header.</h2>
 <ol>
 <li>This is the first list item.</li>
 <li>This is the second list item.</li>
@@ -132,16 +139,6 @@ Markdown produces from the above list is:</p>
 <li>McHale</li>
 <li>Parish</li>
 </ol>
-<p>or even:</p>
-<ol>
-<li>Bird</li>
-<li>McHale</li>
-<li>Parish</li>
-</ol>
-<p>you'd get the exact same HTML output. The point is, if you want to,
-you can use ordinal numbers in your ordered Markdown lists, so that
-the numbers in your source match the numbers in your published HTML.
-But if you want to be lazy, you don't have to.</p>
 <p>To make lists look nice, you can wrap items with hanging indents:</p>
 <ul>
 <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
@@ -188,7 +185,8 @@ sit amet, consectetuer adipiscing elit.</p>
 delimiters need to be indented:</p>
 <ul>
 <li><p>A list item with a blockquote:</p>
-<blockquote><p>This is a blockquote
+<blockquote>
+<p>This is a blockquote
 inside a list item.</p>
 </blockquote>
 </li>
@@ -211,17 +209,13 @@ in both <code>&lt;pre&gt;</code> and <code>&lt;code&gt;</code> tags.</p>
 block by at least 4 spaces or 1 tab.</p>
 <p>This is a normal paragraph:</p>
 <ac:structured-macro ac:name="code"><ac:parameter ac:name="linenumbers">true</ac:parameter>
-<ac:plain-text-body><![CDATA[This is a code block.
-
-]]></ac:plain-text-body>
+<ac:plain-text-body><![CDATA[This is a code block.]]></ac:plain-text-body>
 </ac:structured-macro>
 <p>Here is an example of AppleScript:</p>
 <ac:structured-macro ac:name="code"><ac:parameter ac:name="linenumbers">true</ac:parameter>
 <ac:plain-text-body><![CDATA[tell application "Foo"
     beep
-end tell
-
-]]></ac:plain-text-body>
+end tell]]></ac:plain-text-body>
 </ac:structured-macro>
 <p>A code block continues until it reaches a line that is not indented
 (or the end of the article).</p>
@@ -233,9 +227,7 @@ ampersands and angle brackets. For example, this:</p>
 <ac:structured-macro ac:name="code"><ac:parameter ac:name="linenumbers">true</ac:parameter>
 <ac:plain-text-body><![CDATA[<div class="footer">
     &copy; 2004 Foo Corporation
-</div>
-
-]]></ac:plain-text-body>
+</div>]]></ac:plain-text-body>
 </ac:structured-macro>
 <p>Regular Markdown syntax is not processed within code blocks. E.g.,
 asterisks are just literal asterisks within a code block. This means
@@ -243,7 +235,8 @@ it's also easy to use Markdown to write about Markdown's own syntax.</p>
 <ac:structured-macro ac:name="code"><ac:parameter ac:name="linenumbers">true</ac:parameter>
 <ac:plain-text-body><![CDATA[tell application "Foo"
     beep
-end tell]]></ac:plain-text-body>
+end tell
+]]></ac:plain-text-body>
 </ac:structured-macro>
 <h2>Span Elements</h2>
 <h3>Links</h3>

--- a/tests/functional/test.md
+++ b/tests/functional/test.md
@@ -1,20 +1,18 @@
 # Markdown: Syntax
 
-*   [Overview](#overview)
-    *   [Philosophy](#philosophy)
-    *   [Inline HTML](#html)
-    *   [Automatic Escaping for Special Characters](#autoescape)
-*   [Block Elements](#block)
-    *   [Paragraphs and Line Breaks](#p)
-    *   [Headers](#header)
-    *   [Blockquotes](#blockquote)
-    *   [Lists](#list)
-    *   [Code Blocks](#precode)
-    *   [Horizontal Rules](#hr)
-*   [Span Elements](#span)
-    *   [Links](#link)
-    *   [Emphasis](#em)
-    *   [Code](#code)
+- [Markdown: Syntax](#markdown-syntax)
+  - [Overview](#overview)
+    - [Philosophy](#philosophy)
+  - [Block Elements](#block-elements)
+    - [Paragraphs and Line Breaks](#paragraphs-and-line-breaks)
+    - [Headers](#headers)
+    - [Blockquotes](#blockquotes)
+    - [Lists](#lists)
+    - [Code Blocks](#code-blocks)
+  - [Span Elements](#span-elements)
+    - [Links](#links)
+    - [Emphasis](#emphasis)
+    - [Code](#code)
 
 
 **Note:** This document is itself written using Markdown; you
@@ -153,17 +151,6 @@ If you instead wrote the list in Markdown like this:
 1.  Bird
 1.  McHale
 1.  Parish
-
-or even:
-
-3. Bird
-1. McHale
-8. Parish
-
-you'd get the exact same HTML output. The point is, if you want to,
-you can use ordinal numbers in your ordered Markdown lists, so that
-the numbers in your source match the numbers in your published HTML.
-But if you want to be lazy, you don't have to.
 
 To make lists look nice, you can wrap items with hanging indents:
 

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -99,7 +99,7 @@ def test_tag_render_with_child_and_text():
 
 def test_renderer_reinit():
     renderer = ConfluenceRenderer()
-    renderer.header("this is a title", 1)
+    renderer.heading("this is a title", 1)
     assert renderer.title is not None
 
     renderer.reinit()
@@ -138,7 +138,7 @@ def test_renderer_header_sets_title():
     test_header = "this is a header"
     renderer = ConfluenceRenderer()
 
-    renderer.header(test_header, 1)
+    renderer.heading(test_header, 1)
 
     assert renderer.title == test_header
 
@@ -147,7 +147,7 @@ def test_renderer_strips_header():
     test_header = "this is a header"
     renderer = ConfluenceRenderer(strip_header=True)
 
-    result = renderer.header(test_header, 1)
+    result = renderer.heading(test_header, 1)
 
     assert result == ""
 
@@ -156,7 +156,7 @@ def test_renderer_header_lower_level_does_not_set_title():
     test_header = "this is a header"
     renderer = ConfluenceRenderer()
 
-    renderer.header(test_header, 2)
+    renderer.heading(test_header, 2)
 
     assert renderer.title is None
 
@@ -166,8 +166,8 @@ def test_renderer_header_later_level_sets_title():
     test_header = "this is a header"
     renderer = ConfluenceRenderer()
 
-    renderer.header(test_lower_header, 2)
-    renderer.header(test_header, 1)
+    renderer.heading(test_lower_header, 2)
+    renderer.heading(test_header, 1)
 
     assert renderer.title is test_header
 
@@ -177,8 +177,8 @@ def test_renderer_header_only_sets_first_title():
     test_second_header = "this is another header"
     renderer = ConfluenceRenderer()
 
-    renderer.header(test_header, 1)
-    renderer.header(test_second_header, 1)
+    renderer.heading(test_header, 1)
+    renderer.heading(test_second_header, 1)
 
     assert renderer.title is test_header
 


### PR DESCRIPTION
I noticed mistune was pinned to version 0.8.4, I updated it to v 3.0.1 (which covers #81 and #82 ((sorry))), all tests passing too.

While at it, I added the escape parameter mentioned on #34, which enables the rendering of quotes and other symbols instead of html escaped symbols.
I added that to the library but not to the CLI, the default is to not escape HTML stuff.

My main goal is to be able to get unescaped HTML, mainly for linking other confluence pages and maybe adding macros as mentioned on #34, But I though the new Mistune could handle it, let's see if that works.
