### PR TITLE
Implement --clear flag to delete subpages before uploading

### DIFF
--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -327,14 +327,14 @@ def main():
         pages_to_delete = []
         if args.parent_id:
             pages_to_delete = confluence.get_all_pages_from_parent_id(args.parent_id)
-
+            
         # Don't implement cleaning of whole space
         # else:
         #    pages_to_delete = confluence.get_all_pages_from_space(args.space)
 
         for page in pages_to_delete:
             try:
-                confluence.delete_page(page.id)
+                confluence.delete_page(page)
                 console.log(f"Deleted page {page.title}")
             except HTTPError as e:
                 error_console.log(

--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -324,10 +324,13 @@ def main():
 
     # if --clear is detected, we need to delete all the pages in the space or subpages of the parent pages
     if args.clear:
+        pages_to_delete = []
         if args.parent_id:
             pages_to_delete = confluence.get_all_pages_from_parent_id(args.parent_id)
-        else:
-            pages_to_delete = confluence.get_all_pages_from_space(args.space)
+
+        # Don't implement cleaning of whole space
+        # else:
+        #    pages_to_delete = confluence.get_all_pages_from_space(args.space)
 
         for page in pages_to_delete:
             try:

--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -246,7 +246,7 @@ def get_parser():
     parser.add_argument(
         "--clear",
         action="store_true",
-        help="delete all subpages in the space or of the parent pages before uploading new ones.",
+        help="delete all subpages of the parent pages before uploading new ones",
     )
     parser.add_argument(
         "file_list",
@@ -328,18 +328,8 @@ def main():
         if args.parent_id:
             pages_to_delete = confluence.get_all_pages_from_parent_id(args.parent_id)
 
-        # Don't implement cleaning of whole space
-        # else:
-        #    pages_to_delete = confluence.get_all_pages_from_space(args.space)
-
         for page in pages_to_delete:
-            try:
-                confluence.delete_page(page.id)
-                console.log(f"Deleted page {page.title}")
-            except HTTPError as e:
-                error_console.log(
-                    f"Failed to delete page {page.title} with error {e.response.content}"
-                )
+            delete_page_and_subpages(confluence, page.id)
 
     pages_to_upload = collect_pages_to_upload(args)
 
@@ -762,6 +752,19 @@ def collect_pages_to_upload(args):
                 only_page.relative_links = []
 
     return pages_to_upload
+
+
+def delete_page_and_subpages(confluence, page_id):
+    pages_to_delete = confluence.get_all_pages_from_parent_id(page_id)
+    for page in pages_to_delete:
+        try:
+            confluence.delete_page_and_subpages(page.id)
+            console.log(f"Deleted page {page.title}")
+        except HTTPError as e:
+            error_console.log(
+                f"Failed to delete page {page.title} with error {e.response.content}"
+            )
+    confluence.delete_page(page_id)
 
 
 if __name__ == "__main__":

--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -66,7 +66,11 @@ class MinimalConfluence:
     def _request(self, method, path, **kwargs):
         r = self.api.request(method, urljoin(self.host, path), **kwargs)
         r.raise_for_status()
-        return bunchify(r.json())
+        
+        if r.status_code != 204:
+            return bunchify(r.json())
+        else:
+            return None
 
     def _get(self, path, **kwargs):
         return self._request("GET", path, **kwargs)
@@ -219,7 +223,8 @@ class MinimalConfluence:
         return self._delete(f"content/{confluence_page.id}")
 
     def get_all_pages_from_parent_id(self, parent_id):
-        return self._get(f"content/{parent_id}/child/page")
+        pages = self._get(f"content/{parent_id}/child/page")['results']
+        return pages
 
     def get_attachment(self, confluence_page, name):
         existing_attachments = self._get(

--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -77,6 +77,9 @@ class MinimalConfluence:
     def _put(self, path, **kwargs):
         return self._request("PUT", path, **kwargs)
 
+    def _delete(self, path, **kwargs):
+        return self._request("DELETE", path, **kwargs)
+
     def get_page(
         self,
         title=None,
@@ -211,6 +214,9 @@ class MinimalConfluence:
             }
 
         return self._put(f"content/{page.id}", json=update_structure)
+
+    def delete_page(self, confluence_page):
+        return self._delete(f"content/{confluence_page.id}")
 
     def get_attachment(self, confluence_page, name):
         existing_attachments = self._get(

--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -218,6 +218,9 @@ class MinimalConfluence:
     def delete_page(self, confluence_page):
         return self._delete(f"content/{confluence_page.id}")
 
+    def get_all_pages_from_parent_id(self, parent_id):
+        return self._get(f"content/{parent_id}/child/page")
+
     def get_attachment(self, confluence_page, name):
         existing_attachments = self._get(
             f"content/{confluence_page.id}/child/attachment",


### PR DESCRIPTION
Refer to: https://github.com/iamjackg/md2cf/issues/62

Adding the --clear flag to a command will first delete all subpages of the parent page before uploading the new ones