### PR TITLE
Added flag --title-from-filename to always use the filename as the page title 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ The title of the page can be sourced from multiple places, in the following orde
 * The first top-level header found in the document (i.e., the first `#` header)
 * The filename, if there are no top-level headers.
 
+You can also use the `--title-from-filename` option to overwrite this behaviour.
+This will always use the filename as the page title, even if there are top-level headers or a title entry in the front matter of the document.
+
 Note that if you are reading from standard input, you must either specify the title through the command line or include a title as a header or in the front matter within the content.
 
 To avoid repeating the top level header in the body of the page, pass the `--strip-top-header` parameter to strip it from the document.

--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -98,10 +98,16 @@ def get_parser():
         help="upload the page tree starting from the top level (no top level parent)",
     )
 
-    page_group.add_argument(
+    title_group = page_group.add_mutually_exclusive_group()
+    title_group.add_argument(
         "-t",
         "--title",
         help="a title for the page. Determined from the document if missing",
+    )
+    title_group.add_argument(
+        "--title-from-filename",
+        action="store_true",
+        help="use the filename as the title of the page",
     )
 
     page_group.add_argument(
@@ -681,6 +687,13 @@ def collect_pages_to_upload(args):
             )
             sys.exit(1)
 
+        if args.title_from_filename:
+            error_console.log(
+                "You cannot specify --title-from-filename "
+                "if uploading from standard input\n"
+            )
+            sys.exit(1)
+
         if args.title:
             pages_to_upload[0].title = args.title
     else:
@@ -697,6 +710,7 @@ def collect_pages_to_upload(args):
                     use_pages_file=args.use_pages_file,
                     use_gitignore=args.use_gitignore,
                     enable_relative_links=args.enable_relative_links,
+                    page_title_from_filename=args.title_from_filename,
                 )
             else:
                 try:
@@ -709,6 +723,7 @@ def collect_pages_to_upload(args):
                             strip_header=args.strip_top_header,
                             remove_text_newlines=args.remove_text_newlines,
                             enable_relative_links=enable_relative_links,
+                            page_title_from_filename=args.title_from_filename,
                         )
                     )
                 except FileNotFoundError:

--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -107,7 +107,7 @@ def get_parser():
     title_group.add_argument(
         "--title-from-filename",
         action="store_true",
-        help="use the filename as the title of the page",
+        help="always use the filename as the title of the page",
     )
 
     page_group.add_argument(

--- a/md2cf/document.py
+++ b/md2cf/document.py
@@ -91,6 +91,7 @@ def get_pages_from_directory(
     remove_text_newlines: bool = False,
     use_gitignore: bool = True,
     enable_relative_links: bool = False,
+    page_title_from_filename: bool = False,
 ) -> List[Page]:
     """
     Collect a list of markdown files recursively under the file_path directory.
@@ -107,6 +108,7 @@ def get_pages_from_directory(
       search
     :param enable_relative_links: extract all relative links and replace them with
       placeholders
+    :param page_title_from_filename: use the filename as the page title
     :return: A list of paths to the markdown files to upload.
     """
     processed_pages = list()
@@ -193,6 +195,7 @@ def get_pages_from_directory(
                 strip_header=strip_header,
                 remove_text_newlines=remove_text_newlines,
                 enable_relative_links=enable_relative_links,
+                page_title_from_filename=page_title_from_filename,
             )
             processed_page.parent_title = parent_page_title
             processed_pages.append(processed_page)
@@ -211,6 +214,7 @@ def get_page_data_from_file_path(
     strip_header: bool = False,
     remove_text_newlines: bool = False,
     enable_relative_links: bool = False,
+    page_title_from_filename: bool = False,
 ) -> Page:
     if not isinstance(file_path, Path):
         file_path = Path(file_path)
@@ -231,7 +235,7 @@ def get_page_data_from_file_path(
         enable_relative_links=enable_relative_links,
     )
 
-    if not page.title:
+    if page_title_from_filename or not page.title:
         page.title = file_path.stem
 
     page.file_path = file_path

--- a/test_package/unit/test_argument_parser.py
+++ b/test_package/unit/test_argument_parser.py
@@ -1,0 +1,22 @@
+import pytest
+
+from md2cf.__main__ import get_parser
+
+
+def test_specify_both_title_and_title_from_filename_does_exit():
+    parser = get_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--title", "some-title", "--title-from-filename"])
+
+
+def test_specify_only_title_does_not_exit():
+    parser = get_parser()
+
+    parser.parse_args(["--title", "some-title"])
+
+
+def test_specify_only_title_from_filename_does_not_exit():
+    parser = get_parser()
+
+    parser.parse_args(["--title-from-filename"])

--- a/test_package/unit/test_document_title.py
+++ b/test_package/unit/test_document_title.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import md2cf.document as doc
+from test_package.utils import FakePage
+
+
+def test_get_page_title_from_file(fs):
+    fs.create_file("/root-folder/some-page.md", contents="# Title from within file")
+
+    result = doc.get_page_data_from_file_path(
+        Path("/root-folder/some-page.md"), page_title_from_filename=False
+    )
+    assert result == FakePage(
+        title="Title from within file",
+    )
+
+
+def test_get_page_title_from_filename_if_no_title_in_file(fs):
+    fs.create_file("/root-folder/some-page.md")
+
+    result = doc.get_page_data_from_file_path(
+        Path("/root-folder/some-page.md"), page_title_from_filename=False
+    )
+    assert result == FakePage(
+        title="some-page",
+    )
+
+
+def test_get_page_title_from_filename_if_no_page_title_in_file(fs):
+    fs.create_file("/root-folder/some-page.md", contents="")
+
+    result = doc.get_page_data_from_file_path(
+        Path("/root-folder/some-page.md"), page_title_from_filename=True
+    )
+    assert result == FakePage(
+        title="some-page",
+    )
+
+
+def test_get_page_title_from_filename_if_page_title_in_file(fs):
+    fs.create_file("/root-folder/some-page.md", contents="# Title from within file")
+
+    result = doc.get_page_data_from_file_path(
+        Path("/root-folder/some-page.md"), page_title_from_filename=True
+    )
+    assert result == FakePage(
+        title="some-page",
+    )


### PR DESCRIPTION
I am currently adopting md2cf in my ci workflows.
The workflow I am mainly going to use is uploading multiple files inside of a folder recursively.

I found that the current way of determining the page title produces inconsistent results, as some of my markdown files have a top-level header and some do not.
To make this more consistent, I would like to always use the filename as the page title.

Therefore I propose to add a new option to the `md2cf` command, which allows to explicitly tell the application to always use the filename as the page title, regardless of the file content.