### PR TITLE
Add some handling for tag edge cases

### DIFF
--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -1,3 +1,4 @@
+import json
 from urllib.parse import urljoin
 
 import requests
@@ -207,7 +208,9 @@ class MinimalConfluence:
 
         if labels is not None:
             update_structure["metadata"] = {
-                "labels": [{"name": label, "prefix": "global"} for label in labels]
+                "labels": json.dumps(
+                    [{"name": label, "prefix": "global"} for label in labels]
+                )
             }
 
         return self._put(f"content/{page.id}", json=update_structure)
@@ -243,7 +246,8 @@ class MinimalConfluence:
         # return self.api.content(page.id).post(
         return self._post(
             f"content/{page.id}/label",
-            data=[{"name": label, "type": "global"} for label in labels],
+            data=json.dumps([{"name": label, "type": "global"} for label in labels]),
+            headers={"Content-Type": "application/json"},
         )
 
     def get_url(self, page):

--- a/md2cf/upsert.py
+++ b/md2cf/upsert.py
@@ -126,10 +126,9 @@ def labels_need_updating(page, existing_page):
 
     if sorted(
         [
-            label.name
-            for label in existing_page.get("metadata", {})
-            .get("labels", {})
-            .get("results", {})
+            # Use `get()` here for unit test sanity -- `Mock().name` is reserved.
+            label.get("name")
+            for label in existing_page.get("metadata", {"labels": {"results": {}}})
         ]
     ) != sorted(page.labels):
         return True

--- a/md2cf/upsert.py
+++ b/md2cf/upsert.py
@@ -125,7 +125,12 @@ def labels_need_updating(page, existing_page):
         return False
 
     if sorted(
-        [label.name for label in existing_page.metadata.labels.results]
+        [
+            label.name
+            for label in existing_page.get("metadata", {})
+            .get("labels", {})
+            .get("results", {})
+        ]
     ) != sorted(page.labels):
         return True
 

--- a/test_package/unit/test_upsert.py
+++ b/test_package/unit/test_upsert.py
@@ -276,16 +276,14 @@ def test_page_needs_updating_content_replace_all_labels_and_labels_not_changed(m
     )
 
     message_hash = "[v6e71b3cac15d32fe2d36c270887df9479c25c640]"
-    existing_page_mock = mocker.Mock()
+    existing_page_mock = mocker.Mock(
+        get=mocker.Mock(return_value=[{"name": label} for label in labels])
+    )
     ancestor_mock = mocker.Mock()
     ancestor_mock.id = mocker.sentinel.parent_id
     existing_page_mock.ancestors = [ancestor_mock]
     existing_page_mock.version.message = message_hash
     existing_page_mock.metadata.labels.results = []
-    for label in labels:
-        label_mock = mocker.Mock()
-        label_mock.name = label
-        existing_page_mock.metadata.labels.results.append(label_mock)
 
     assert not md2cf.upsert.page_needs_updating(
         page, existing_page_mock, replace_all_labels=True
@@ -424,18 +422,14 @@ def test_page_needs_updating_content_replace_all_labels_and_empty_labels_supplie
     )
 
     message_hash = "[v6e71b3cac15d32fe2d36c270887df9479c25c640]"
-    existing_page_mock = mocker.Mock()
+    labels = ["label1", "label2"]
+    existing_page_mock = mocker.Mock(
+        get=mocker.Mock(return_value=[{"name": label} for label in labels])
+    )
     ancestor_mock = mocker.Mock()
     ancestor_mock.id = mocker.sentinel.parent_id
     existing_page_mock.ancestors = [ancestor_mock]
     existing_page_mock.version.message = message_hash
-
-    labels = ["label1", "label2"]
-    existing_page_mock.metadata.labels.results = []
-    for label in labels:
-        label_mock = mocker.Mock()
-        label_mock.name = label
-        existing_page_mock.metadata.labels.results.append(label_mock)
 
     assert md2cf.upsert.page_needs_updating(
         page, existing_page_mock, replace_all_labels=True
@@ -456,14 +450,35 @@ def test_page_needs_updating_content_replace_all_labels_and_empty_labels_supplie
     )
 
     message_hash = "[v6e71b3cac15d32fe2d36c270887df9479c25c640]"
-    existing_page_mock = mocker.Mock()
+    existing_page_mock = mocker.Mock(get=mocker.Mock(return_value=[]))
     ancestor_mock = mocker.Mock()
     ancestor_mock.id = mocker.sentinel.parent_id
     existing_page_mock.ancestors = [ancestor_mock]
     existing_page_mock.version.message = message_hash
 
-    existing_page_mock.metadata.labels.results = []
-
     assert not md2cf.upsert.page_needs_updating(
+        page, existing_page_mock, replace_all_labels=True
+    )
+
+
+def test_page_needs_updated_created_with_no_labels_and_new_ones_were_added(mocker):
+    """An existing page with no labels was created, and new labels were added
+    after the fact. We should update the page with these new labels"""
+    page = Page(
+        space=mocker.sentinel.space,
+        title=mocker.sentinel.title,
+        body="hello there",
+        labels=["foo"],
+        parent_id=mocker.sentinel.parent_id,
+    )
+
+    message_hash = "[v6e71b3cac15d32fe2d36c270887df9479c25c640]"
+    existing_page_mock = mocker.Mock(get=mocker.Mock(return_value=[]))
+    ancestor_mock = mocker.Mock()
+    ancestor_mock.id = mocker.sentinel.parent_id
+    existing_page_mock.ancestors = [ancestor_mock]
+    existing_page_mock.version.message = message_hash
+
+    assert md2cf.upsert.page_needs_updating(
         page, existing_page_mock, replace_all_labels=True
     )


### PR DESCRIPTION
- Properly handle updating tags if the page doesn't already have them
- JSON-ify tags so Confluence can properly consume the data

Fixes #117 