### PR TITLE
Set a default width for rendering images so they don't get raw wdith

### DIFF
--- a/md2cf/confluence_renderer.py
+++ b/md2cf/confluence_renderer.py
@@ -141,12 +141,26 @@ class ConfluenceRenderer(mistune.Renderer):
         root_element.append(self.plain_text_body(code))
         return root_element.render()
 
-    def image(self, src, title, text):
+    def image(self, src, title, text, width=764, height=None):
+        """
+        Render an image as Confluence Storage Format.
+        See https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html
+
+        :param src: The image source path
+        :param title: The title of the image
+        :param text: Used as alt (tooltip) text for the image
+        :param width: The rendered width of the image, defaults to 764 which seems to work well in Confluence.
+        :param height: Specify the height of the image, relative to width by default.
+        """
         attributes = {"alt": text}
         if title:
             attributes["title"] = title
+        if width:
+            attributes["width"] = width
+        if height:
+            attributes["height"] = height
 
-        root_element = ConfluenceTag(name="image", attrib=attributes)
+        root_element = ConfluenceTag(name="image", attrib=attributes, namespace="ac")
         parsed_source = urlparse(src)
         if not parsed_source.netloc:
             # Local file, requires upload
@@ -158,5 +172,4 @@ class ConfluenceRenderer(mistune.Renderer):
         else:
             url_tag = ConfluenceTag("url", attrib={"value": src}, namespace="ri")
         root_element.append(url_tag)
-
         return root_element.render()

--- a/md2cf/confluence_renderer.py
+++ b/md2cf/confluence_renderer.py
@@ -141,7 +141,7 @@ class ConfluenceRenderer(mistune.Renderer):
         root_element.append(self.plain_text_body(code))
         return root_element.render()
 
-    def image(self, src, title, text, width=764, height=None):
+    def image(self, src, title, text, width=768, height=None):
         """
         Render an image as Confluence Storage Format.
         See https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html
@@ -149,7 +149,7 @@ class ConfluenceRenderer(mistune.Renderer):
         :param src: The image source path
         :param title: The title of the image
         :param text: Used as alt (tooltip) text for the image
-        :param width: The rendered width of the image, defaults to 764 which seems to work well in Confluence.
+        :param width: The rendered width of the image, defaults to 768 which seems to work well in Confluence.
         :param height: Specify the height of the image, relative to width by default.
         """
         attributes = {"alt": text}

--- a/test_package/unit/test_renderer.py
+++ b/test_package/unit/test_renderer.py
@@ -205,7 +205,7 @@ def test_renderer_header_only_sets_first_title():
 def test_renderer_image_external():
     test_image_src = "http://example.com/image.jpg"
     test_image_markup = (
-        '<ac:image ac:alt=""><ri:url ri:value="{}"></ri:url>\n'
+        '<ac:image ac:alt="" ac:width="764"><ri:url ri:value="{}"></ri:url>\n'
         "</ac:image>\n".format(test_image_src)
     )
 
@@ -220,7 +220,7 @@ def test_renderer_image_external_alt_and_title():
     test_image_alt = "alt text"
     test_image_title = "title"
     test_image_markup = (
-        '<ac:image ac:alt="{}" ac:title="{}"><ri:url ri:value="{}"></ri:url>\n'
+        '<ac:image ac:alt="{}" ac:title="{}" ac:width="764"><ri:url ri:value="{}"></ri:url>\n'
         "</ac:image>\n".format(test_image_alt, test_image_title, test_image_src)
     )
 
@@ -236,7 +236,7 @@ def test_renderer_image_internal_absolute():
     test_image_file = "image.jpg"
     test_image_src = "/home/test/images/" + test_image_file
     test_image_markup = (
-        '<ac:image ac:alt=""><ri:attachment ri:filename="{}"></ri:attachment>\n'
+        '<ac:image ac:alt="" ac:width="764"><ri:attachment ri:filename="{}"></ri:attachment>\n'
         "</ac:image>\n".format(test_image_file)
     )
 
@@ -250,7 +250,7 @@ def test_renderer_image_internal_relative():
     test_image_file = "image.jpg"
     test_image_src = "test/images/" + test_image_file
     test_image_markup = (
-        '<ac:image ac:alt=""><ri:attachment ri:filename="{}"></ri:attachment>\n'
+        '<ac:image ac:alt="" ac:width="764"><ri:attachment ri:filename="{}"></ri:attachment>\n'
         "</ac:image>\n".format(test_image_file)
     )
 

--- a/test_package/unit/test_renderer.py
+++ b/test_package/unit/test_renderer.py
@@ -205,7 +205,7 @@ def test_renderer_header_only_sets_first_title():
 def test_renderer_image_external():
     test_image_src = "http://example.com/image.jpg"
     test_image_markup = (
-        '<ac:image ac:alt="" ac:width="764"><ri:url ri:value="{}"></ri:url>\n'
+        '<ac:image ac:alt="" ac:width="768"><ri:url ri:value="{}"></ri:url>\n'
         "</ac:image>\n".format(test_image_src)
     )
 
@@ -220,7 +220,7 @@ def test_renderer_image_external_alt_and_title():
     test_image_alt = "alt text"
     test_image_title = "title"
     test_image_markup = (
-        '<ac:image ac:alt="{}" ac:title="{}" ac:width="764"><ri:url ri:value="{}"></ri:url>\n'
+        '<ac:image ac:alt="{}" ac:title="{}" ac:width="768"><ri:url ri:value="{}"></ri:url>\n'
         "</ac:image>\n".format(test_image_alt, test_image_title, test_image_src)
     )
 
@@ -236,7 +236,7 @@ def test_renderer_image_internal_absolute():
     test_image_file = "image.jpg"
     test_image_src = "/home/test/images/" + test_image_file
     test_image_markup = (
-        '<ac:image ac:alt="" ac:width="764"><ri:attachment ri:filename="{}"></ri:attachment>\n'
+        '<ac:image ac:alt="" ac:width="768"><ri:attachment ri:filename="{}"></ri:attachment>\n'
         "</ac:image>\n".format(test_image_file)
     )
 
@@ -250,7 +250,7 @@ def test_renderer_image_internal_relative():
     test_image_file = "image.jpg"
     test_image_src = "test/images/" + test_image_file
     test_image_markup = (
-        '<ac:image ac:alt="" ac:width="764"><ri:attachment ri:filename="{}"></ri:attachment>\n'
+        '<ac:image ac:alt="" ac:width="768"><ri:attachment ri:filename="{}"></ri:attachment>\n'
         "</ac:image>\n".format(test_image_file)
     )
 


### PR DESCRIPTION
This PR depends on https://github.com/iamjackg/md2cf/pull/120

Currently images are rendered in default resolution when we push them to Confluence. For retina style screenshots for example this ends up unreadable in the final page. Here's an example:

<img width="985" alt="Screenshot 2023-11-21 at 10 56 40" src="https://github.com/iamjackg/md2cf/assets/231258/3403b5c2-9089-4103-9769-cbc9f477ae38">

This PR sets the correct namespace and a default width for all uploaded images equal to the 764px width of the confluence page text. The end result is a correctly scaled screenshot like in this example:

<img width="927" alt="Screenshot 2023-11-21 at 10 57 09" src="https://github.com/iamjackg/md2cf/assets/231258/c2a8b80d-e336-48e0-8c5b-4af2107f7158">
