### PR TITLE
Resolve title conflicts by prefixing with parent title

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ Alternatively, you can create a YAML file called `.pages` in every folder you wa
 title: "This is a fantastic title!"
 ```
 
+#### Prefixing to prevent title collisions
+
+Confluence enforces that every page in a space have a unique title.  If you have `folder1/overview.md` and `folder2/overview.md`, then you would have a conflict since both pages would
+have a title of `Overview`.  You can add a `.pages.` file to each folder with the following format to add the folder's title as a prefix to each page.
+
+```yaml
+add-parent-title-as-prefix: true
+```
+
+The result will be a page called `Folder1 Overview` and a page called `Folder2 Overview`.
+
 #### Collapse single pages
 
 You can collapse directories that only contain one document by passing the `--collapse-single-pages` parameter.

--- a/md2cf/document.py
+++ b/md2cf/document.py
@@ -61,9 +61,11 @@ class Page(object):
                         ["space", self.space],
                         [
                             "body",
-                            f"{self.body[:40]} [...]"
-                            if len(self.body) > 40
-                            else self.body,
+                            (
+                                f"{self.body[:40]} [...]"
+                                if len(self.body) > 40
+                                else self.body
+                            ),
                         ],
                     ]
                 ]
@@ -167,12 +169,18 @@ def get_pages_from_directory(
                         .capitalize()
                     )
                 folder_title = parent_page_title
+        use_parent_title_as_prefix = False
         if use_pages_file and ".pages" in file_names:
             with open(current_path.joinpath(".pages")) as pages_fp:
                 pages_file_contents = yaml.safe_load(pages_fp)
             if "title" in pages_file_contents:
                 parent_page_title = pages_file_contents["title"]
                 folder_title = parent_page_title
+            if (
+                "add-parent-title-as-prefix" in pages_file_contents
+                and pages_file_contents["add-parent-title-as-prefix"]
+            ):
+                use_parent_title_as_prefix = True
 
         folder_data[current_path]["title"] = folder_title
 
@@ -196,6 +204,8 @@ def get_pages_from_directory(
             )
             processed_page.parent_title = parent_page_title
             processed_pages.append(processed_page)
+            if use_parent_title_as_prefix:
+                processed_page.title = parent_page_title + " " + processed_page.title
 
             # This replaces the title for the current folder with the title for the
             # document we just parsed, so things below this folder will be correctly

--- a/test_package/unit/test_document.py
+++ b/test_package/unit/test_document.py
@@ -231,6 +231,39 @@ def test_get_pages_from_directory_with_pages_file_multi_level(fs):
     ]
 
 
+def test_get_pages_from_directory_with_pages_file_multi_level_conflicting_titles(fs):
+    fs.create_file("/root-folder/sub-folder-a/some-page.md")
+    fs.create_file("/root-folder/sub-folder-b/some-page.md")
+    fs.create_file(
+        "/root-folder/sub-folder-a/.pages",
+        contents='title: "Folder A"\nadd-parent-title-as-prefix: true',
+    )
+    fs.create_file(
+        "/root-folder/sub-folder-b/.pages",
+        contents='title: "Folder B"\nadd-parent-title-as-prefix: true',
+    )
+
+    result = doc.get_pages_from_directory(Path("/root-folder"), use_pages_file=True)
+    assert result == [
+        FakePage(
+            title="Folder A",
+        ),
+        FakePage(
+            title="Folder A some-page",
+            file_path=Path("/root-folder/sub-folder-a/some-page.md"),
+            parent_title="Folder A",
+        ),
+        FakePage(
+            title="Folder B",
+        ),
+        FakePage(
+            title="Folder B some-page",
+            file_path=Path("/root-folder/sub-folder-b/some-page.md"),
+            parent_title="Folder B",
+        ),
+    ]
+
+
 def test_get_pages_from_directory_with_pages_file_single_level(fs):
     fs.create_file("/root-folder/some-page.md")
     fs.create_file("/root-folder/.pages", contents='title: "Root folder"')


### PR DESCRIPTION
Implementation for https://github.com/iamjackg/md2cf/issues/126

This adds the ability to prefix a page's title with it's parent page's title.  This can prevent title conflicts.  This is an opt-in feature on a per-folder basis.  You must put the following in the folders .pages file
```yaml
add-parent-title-as-prefix: true
```